### PR TITLE
Add competition mode and prompt model options

### DIFF
--- a/lofn/image_generation.py
+++ b/lofn/image_generation.py
@@ -244,6 +244,9 @@ def generate_image_dalle3(params, OPENAI_API = Config.OPENAI_API, debug = False)
 
 @st.cache_data(persist=True)
 def generate_dalle_images(input, concept, medium, df_prompts, max_retries, temperature, model, debug, image_model, style_axes, creativity_spectrum, OPENAI_API = Config.OPENAI_API, reasoning_level = 'medium'):
+    if image_model == "None":
+        st.write("Image generation skipped.")
+        return
     st.write(f"Generating images using {image_model}...")
     
     all_prompts = pd.concat([df_prompts['Revised Prompts'], df_prompts['Synthesized Prompts']])
@@ -262,7 +265,8 @@ def generate_dalle_images(input, concept, medium, df_prompts, max_retries, tempe
                 for i, result in enumerate(results):
                     try:
                         # Display the image
-                        st.image(result, caption=f"Generated image {i+1} for {concept} in {medium} - Prompt: {prompt}")
+                        st.image(result, caption=f"Generated image {i+1} for {concept} in {medium}")
+                        st.text_area("Prompt", prompt, key=f"prompt_{index}_{i}")
                         
                         # Generate a title for the image
                         try:
@@ -678,7 +682,7 @@ def get_model_params(model: str):
             "num_inference_steps": st.session_state.get(f"{model}_inference_steps", 12),
             "enable_safety_checker": st.session_state.get(f"{model}_enable_safety_checker", True)
         },
-        "fal-ai/flux/dev": {
+        "fal-ai/flux-dev": {
             "num_inference_steps": st.session_state.get(f"{model}_inference_steps", 28),
             "guidance_scale": st.session_state.get(f"{model}_guidance_scale", 3.5),
             "enable_safety_checker": st.session_state.get(f"{model}_enable_safety_checker", True)
@@ -841,7 +845,7 @@ def render_image_controls(model: str):
         st.selectbox("Image Size", ["portrait_4_3", "portrait_16_9",  "square_hd", "square", "landscape_4_3", "landscape_16_9"], key=f"{model}_image_size")
         st.selectbox("Generation Style", ["any", "realistic_image", "digital_illustration", "vector_illustration", "realistic_image/b_and_w", "realistic_image/hard_flash", "realistic_image/hdr", "realistic_image/natural_light", "realistic_image/studio_portrait", "realistic_image/enterprise", "realistic_image/motion_blur", "digital_illustration/pixel_art", "digital_illustration/hand_drawn", "digital_illustration/grain", "digital_illustration/infantile_sketch", "digital_illustration/2d_art_poster", "digital_illustration/handmade_3d", "digital_illustration/hand_drawn_outline", "digital_illustration/engraving_color", "digital_illustration/2d_art_poster_2", "vector_illustration/engraving", "vector_illustration/line_art", "vector_illustration/line_circuit", "vector_illustration/linocut"], key=f"{model}_recraft_style")
         st.checkbox("Enable Safety Checker", value=True, key=f"{model}_enable_safety_checker")
-    elif model in ["fal-ai/flux/dev", "fal-ai/flux-realism","fal-ai/stable-diffusion-v35-medium", "fal-ai/omnigen-v1", "fal-ai/stable-diffusion-v35-large", "fal-ai/flux-pro", "fal-ai/flux-pro/v1.1", "Poe-FLUX-pro-1.1", "Poe-FLUX-pro", "Poe-Ideogram-v2", "Poe-Ideogram", "Poe-Imagen3", "Poe-StableDiffusion3.5-L", "Poe-StableDiffusion3", "Poe-SD3-Turbo", "fal-ai/stable-diffusion-v3", "Poe-FLUX-dev"]:
+    elif model in ["fal-ai/flux-dev", "fal-ai/flux-realism","fal-ai/stable-diffusion-v35-medium", "fal-ai/omnigen-v1", "fal-ai/stable-diffusion-v35-large", "fal-ai/flux-pro", "fal-ai/flux-pro/v1.1", "Poe-FLUX-pro-1.1", "Poe-FLUX-pro", "Poe-Ideogram-v2", "Poe-Ideogram", "Poe-Imagen3", "Poe-StableDiffusion3.5-L", "Poe-StableDiffusion3", "Poe-SD3-Turbo", "fal-ai/stable-diffusion-v3", "Poe-FLUX-dev"]:
         st.selectbox("Image Size", ["portrait_4_3", "portrait_16_9",  "square_hd", "square", "landscape_4_3", "landscape_16_9"], key=f"{model}_image_size")
         st.number_input("Inference Steps", min_value=1, max_value=50, value=50, key=f"{model}_inference_steps")
         st.number_input("Guidance Scale", min_value=0.0, max_value=20.0, value=7.0, step=0.1, key=f"{model}_guidance_scale")

--- a/lofn/ui.py
+++ b/lofn/ui.py
@@ -22,6 +22,7 @@ class LofnError(Exception):
 class LofnApp:
     def __init__(self):
         self.model = None
+        self.prompt_model = None
         self.image_model = None
         self.temperature = 0.7
         self.max_retries = 3
@@ -106,7 +107,7 @@ class LofnApp:
         return models
 
     def get_available_image_models(self):
-        models = []
+        models = ["None"]
         if Config.FAL_API_KEY:
             models.extend([
                 "fal-ai/flux-pro/v1.1-ultra", "fal-ai/flux-pro/v1.1", "fal-ai/recraft-v3",
@@ -156,6 +157,18 @@ class LofnApp:
     def render_sidebar(self):
         st.sidebar.header('Settings')
 
+        st.session_state['competition_mode'] = st.sidebar.checkbox(
+            'Competition Mode', value=st.session_state.get('competition_mode', False)
+        )
+        if st.session_state['competition_mode']:
+            st.session_state['competition_text'] = st.sidebar.text_input(
+                'Competition Text', value=st.session_state.get('competition_text', '')
+            )
+            st.session_state['num_best_pairs'] = st.sidebar.number_input(
+                'Top Pairs', min_value=1, max_value=10,
+                value=st.session_state.get('num_best_pairs', 3), step=1
+            )
+
         # Language Model Settings
         with st.sidebar.expander("Language Model Settings", expanded=True):
             self.model = st.selectbox(
@@ -163,6 +176,13 @@ class LofnApp:
                 self.available_models,
                 help="Choose the language model for generating concepts and prompts."
             )
+            self.prompt_model = st.selectbox(
+                "Prompt Generation Model",
+                self.available_models,
+                index=self.available_models.index(st.session_state.get('prompt_model', self.available_models[0])) if self.available_models else 0,
+                help="Model used for generating image prompts."
+            )
+            st.session_state['prompt_model'] = self.prompt_model
 
             if self.model.startswith('o1') or self.model.startswith('o3') or self.model.startswith('o4'):
                 # Reasoning Level for o1
@@ -327,6 +347,12 @@ class LofnApp:
             else:
                 style_axes, creativity_spectrum = self.generate_concepts()
 
+        if st.session_state.get('competition_mode') and st.button("Run Competition"):
+            if not st.session_state['input'].strip():
+                st.warning("Please provide a description of your idea.")
+            else:
+                self.run_competition()
+
         # If we have concept_mediums, display them
         if 'concept_mediums' in st.session_state and st.session_state['concept_mediums']:
             self.display_concepts()
@@ -334,10 +360,14 @@ class LofnApp:
     def generate_concepts(self):
         try:
             st.session_state['concept_mediums'] = []
+            input_text = st.session_state['input']
+            if st.session_state.get('competition_mode'):
+                template = read_prompt('/lofn/prompts/competition_prompt.txt')
+                input_text = template.replace('{input}', st.session_state.get('competition_text', input_text))
+            st.session_state['prompt_input'] = input_text
             with st.spinner("Generating concepts..."):
-                # pass the new 'reasoning_level' from session to the generate_concept_mediums
                 concepts, style_axes, creativity_spectrum = generate_concept_mediums(
-                    st.session_state['input'],
+                    input_text,
                     max_retries=self.max_retries,
                     temperature=self.temperature,
                     model=self.model,
@@ -382,12 +412,12 @@ class LofnApp:
         try:
             with st.spinner(f"Generating prompts for '{pair['concept']}'..."):
                 prompts_df = generate_image_prompts(
-                    st.session_state['input'],
+                    st.session_state['prompt_input'],
                     pair['concept'],
                     pair['medium'],
                     max_retries=self.max_retries,
                     temperature=self.temperature,
-                    model=self.model,
+                    model=self.prompt_model,
                     debug=self.debug,
                     style_axes=st.session_state['style_axes'],
                     creativity_spectrum=st.session_state['creativity_spectrum'],
@@ -405,12 +435,12 @@ class LofnApp:
         try:
             with st.spinner(f"Generating prompts for '{concept}'..."):
                 prompts_df = generate_image_prompts(
-                    st.session_state['input'],
+                    st.session_state['prompt_input'],
                     concept,
                     medium,
                     max_retries=self.max_retries,
                     temperature=self.temperature,
-                    model=self.model,
+                    model=self.prompt_model,
                     debug=self.debug,
                     style_axes=st.session_state['style_axes'],
                     creativity_spectrum=st.session_state['creativity_spectrum'],
@@ -434,18 +464,28 @@ class LofnApp:
 
         self.generate_images(prompts_df, pair)
 
+    def run_competition(self):
+        self.generate_concepts()
+        selected = list(range(min(st.session_state.get('num_best_pairs', 3), len(st.session_state.get('concept_mediums', [])))))
+        for idx in selected:
+            pair = st.session_state['concept_mediums'][idx]
+            self.generate_prompts_for_pair(pair)
+
     def generate_images(self, prompts_df, pair):
         st.subheader(f"Generating Images for '{pair['concept']}'")
+        if self.image_model == "None":
+            st.info("Image generation skipped.")
+            return
         try:
             with st.spinner(f"Generating images for '{pair['concept']}'..."):
                 generate_dalle_images(
-                    st.session_state['input'],
+                    st.session_state['prompt_input'],
                     pair['concept'],
                     pair['medium'],
                     prompts_df,
                     max_retries=self.max_retries,
                     temperature=self.temperature,
-                    model=self.model,
+                    model=self.prompt_model,
                     debug=self.debug,
                     image_model=self.image_model,
                     style_axes=st.session_state['style_axes'],
@@ -654,6 +694,11 @@ class LofnApp:
             'proceed_shuffled_reviews_clicked': False,
             'complete_all_steps_clicked': False,
             'image_model': 'Poe-FLUX-pro',
+            'prompt_model': 'gpt-4.1',
+            'competition_mode': False,
+            'competition_text': '',
+            'num_best_pairs': 3,
+            'prompt_input': '',
             'creativity_spectrum': None,
             'style_axes': None,
             'input': '',


### PR DESCRIPTION
## Summary
- add competition mode controls in sidebar
- allow choosing separate model for prompt generation
- create run_competition flow for automatic concept and prompt generation
- support skipping image generation and copying prompts
- fix flux-dev model references and handle `None` image model

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683a82af543483299ccd3fbdb4d011b2