### PR TITLE
Add panel voting for competition mode

### DIFF
--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -67,6 +67,7 @@ revision_synthesis_prompt_middle = read_prompt('/lofn/prompts/revision_synthesis
 dalle3_gen_prompt_middle = read_prompt('/lofn/prompts/dalle3_gen_prompt.txt')
 dalle3_gen_prompt_nodiv_middle = read_prompt('/lofn/prompts/dalle3_gen_nodiv_prompt.txt')
 meta_prompt_generation_prompt = read_prompt('/lofn/prompts/meta_prompt_generation.txt')
+pair_selection_prompt = read_prompt('/lofn/prompts/pair_selection_prompt.txt')
 
 # Video prompts
 video_concept_header_part1 = read_prompt('/lofn/prompts/concept_header.txt')
@@ -261,6 +262,13 @@ music_facets_schema = {
 music_gen_schema = {
     "music_prompt": str,
     "lyrics_prompt": str
+}
+
+# Schema for panel voting on concept-medium pairs
+best_pairs_schema = {
+    "best_pairs": [
+        {"concept": str, "medium": str}
+    ]
 }
 
 
@@ -1464,6 +1472,32 @@ def generate_meta_prompt(input_text, max_retries, temperature, model="gpt-3.5-tu
         return parsed_output
     except Exception as e:
         logger.exception("Error generating meta prompt: %s", e)
+        raise e
+
+def select_best_pairs(input_text, pairs, num_best_pairs, max_retries, temperature, model="gpt-3.5-turbo-16k", debug=False, reasoning_level="medium"):
+    """Use the panel to vote on the best concept-medium pairs."""
+    try:
+        llm = get_llm(model, temperature, Config.OPENAI_API, Config.ANTHROPIC_API, debug, reasoning_level)
+        if model[0] == "o":
+            chain = (
+                ChatPromptTemplate.from_messages([("human", pair_selection_prompt)])
+                | llm
+            )
+        else:
+            chain = (
+                ChatPromptTemplate.from_messages([("system", concept_system), ("human", pair_selection_prompt)])
+                | llm
+            )
+        pairs_json = json.dumps(pairs)
+        args = {
+            "input": input_text,
+            "pairs": pairs_json,
+            "num_best_pairs": num_best_pairs,
+        }
+        parsed_output = run_llm_chain({'vote': chain}, 'vote', args, max_retries, model, debug, expected_schema=best_pairs_schema)
+        return parsed_output.get('best_pairs', [])
+    except Exception as e:
+        logger.exception("Error selecting best pairs: %s", e)
         raise e
 
 def generate_image_prompts(input_text, concept, medium, max_retries, temperature, model="gpt-3.5-turbo-16k", debug=False, style_axes=None, creativity_spectrum=None, reasoning_level="medium"):

--- a/lofn/prompts/pair_selection_prompt.txt
+++ b/lofn/prompts/pair_selection_prompt.txt
@@ -1,0 +1,6 @@
+You are a panel of expert art judges evaluating concept and medium pairs for an art competition.
+Carefully discuss and vote on which pairs best capture the user's idea: "{input}".
+Pairs:
+{pairs}
+Select the top {num_best_pairs} pairs. Return only a JSON object with key "best_pairs" as a list of the chosen pairs in ranked order.
+Example: {"best_pairs": [{"concept": "...", "medium": "..."}]}

--- a/lofn/ui.py
+++ b/lofn/ui.py
@@ -489,9 +489,29 @@ class LofnApp:
 
     def run_competition(self):
         self.generate_concepts()
-        selected = list(range(min(st.session_state.get('num_best_pairs', 3), len(st.session_state.get('concept_mediums', [])))))
-        for idx in selected:
-            pair = st.session_state['concept_mediums'][idx]
+        pairs = st.session_state.get('concept_mediums', [])
+        if not pairs:
+            return
+        try:
+            with st.spinner("Panel voting on best pairs..."):
+                best_pairs = select_best_pairs(
+                    st.session_state['prompt_input'],
+                    pairs,
+                    st.session_state.get('num_best_pairs', 3),
+                    self.max_retries,
+                    self.temperature,
+                    self.model,
+                    self.debug,
+                    st.session_state.get('reasoning_level', 'medium'),
+                )
+            st.session_state['best_pairs'] = best_pairs
+            st.success("Best pairs selected by panel")
+        except Exception as e:
+            st.error("An error occurred while selecting best pairs.")
+            logger.exception("Error selecting best pairs: %s", e)
+            best_pairs = pairs[:min(st.session_state.get('num_best_pairs', 3), len(pairs))]
+
+        for pair in best_pairs:
             self.generate_prompts_for_pair(pair)
 
     def generate_images(self, prompts_df, pair):


### PR DESCRIPTION
## Summary
- allow the panel to vote on concept/medium pairs before image generation
- add `pair_selection_prompt.txt` prompt
- select best pairs via new function `select_best_pairs`
- call panel voting in `run_competition`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683a96a9c4148329a229064ebc873e49