### PR TITLE
Fix widget collisions and progress

### DIFF
--- a/lofn/image_generation.py
+++ b/lofn/image_generation.py
@@ -241,8 +241,6 @@ def generate_image_dalle3(params, OPENAI_API = Config.OPENAI_API, debug = False)
     except Exception as e:
         st.write(f"An error occurred while generating the image with DALL-E 3: {str(e)}")
         return None
-
-@st.cache_data(persist=True)
 def generate_dalle_images(input, concept, medium, df_prompts, max_retries, temperature, model, debug, image_model, style_axes, creativity_spectrum, OPENAI_API = Config.OPENAI_API, reasoning_level = 'medium'):
     if image_model == "None":
         st.write("Image generation skipped.")
@@ -266,7 +264,7 @@ def generate_dalle_images(input, concept, medium, df_prompts, max_retries, tempe
                     try:
                         # Display the image
                         st.image(result, caption=f"Generated image {i+1} for {concept} in {medium}")
-                        st.text_area("Prompt", prompt, key=f"prompt_{index}_{i}")
+                        st.code(prompt, language='')
                         
                         # Generate a title for the image
                         try:

--- a/lofn/ui.py
+++ b/lofn/ui.py
@@ -161,6 +161,9 @@ class LofnApp:
     def render_sidebar(self):
         st.sidebar.header('Settings')
 
+        with st.sidebar.expander('Progress', expanded=True):
+            self.render_progress_dashboard()
+
         st.session_state['competition_mode'] = st.sidebar.checkbox(
             'Competition Mode', value=st.session_state.get('competition_mode', False)
         )
@@ -357,7 +360,7 @@ class LofnApp:
 
     def render_image_main_container(self):
         st.header("Generate Your Art Concept")
-        self.render_progress_dashboard()
+
 
         # The user’s idea. Tying it to session_state so it does not vanish
         st.subheader("Describe Your Idea")
@@ -549,7 +552,8 @@ class LofnApp:
             logger.exception("Error selecting best pairs: %s", e)
             best_pairs = pairs[:min(st.session_state.get('num_best_pairs', 3), len(pairs))]
 
-        for pair in best_pairs:
+        top_n = st.session_state.get('num_best_pairs', 3)
+        for pair in best_pairs[:top_n]:
             self.generate_prompts_for_pair(pair)
 
     def generate_images(self, prompts_df, pair):


### PR DESCRIPTION
## Summary
- prevent widget key collisions by avoiding widgets inside cached function and using `st.code` for prompts
- move progress dashboard to sidebar and remove from main area
- limit top pairs in competition mode

## Testing
- `python -m py_compile lofn/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b321f5c848329ac19922398aa5130