### PR TITLE
Fix widget collisions and remove progress bar

### DIFF
--- a/lofn/image_generation.py
+++ b/lofn/image_generation.py
@@ -241,8 +241,6 @@ def generate_image_dalle3(params, OPENAI_API = Config.OPENAI_API, debug = False)
     except Exception as e:
         st.write(f"An error occurred while generating the image with DALL-E 3: {str(e)}")
         return None
-
-@st.cache_data(persist=True)
 def generate_dalle_images(input, concept, medium, df_prompts, max_retries, temperature, model, debug, image_model, style_axes, creativity_spectrum, OPENAI_API = Config.OPENAI_API, reasoning_level = 'medium'):
     if image_model == "None":
         st.write("Image generation skipped.")
@@ -266,20 +264,16 @@ def generate_dalle_images(input, concept, medium, df_prompts, max_retries, tempe
                     try:
                         # Display the image
                         st.image(result, caption=f"Generated image {i+1} for {concept} in {medium}")
-                        st.text_area("Prompt", prompt, key=f"prompt_{index}_{i}")
+                        st.code(prompt, language='')
                         
                         # Generate a title for the image
                         try:
-                            title_data_json = generate_image_title(input, concept, medium, result, max_retries, temperature, model, debug, reasoning_level)
+                            title_data_json = generate_image_title(
+                                input, concept, medium, result, max_retries,
+                                temperature, model, debug, reasoning_level
+                            )
                             title_data = json.loads(title_data_json)
-                            st.write(f"Generated title: {title_data['title']}")
-                            
-                            # Display Instagram post information
-                            st.subheader("Instagram Post")
-                            st.write(f"Caption: {title_data['instagram_caption']}")
-                            st.write(f"Hashtags: {title_data['instagram_hashtags']}")
-                            st.subheader("SEO Keywords")
-                            st.write(title_data['seo_keywords'])
+                            st.code(json.dumps(title_data, indent=2), language='json')
 
                             # Generate Runway video prompt
                             # runway_prompt_json  = generate_runway_prompt(input, concept, medium, result, prompt, style_axes, creativity_spectrum, max_retries, temperature, model, debug)
@@ -358,7 +352,6 @@ def generate_dalle_images(input, concept, medium, df_prompts, max_retries, tempe
 
     st.write(f"{image_model} image generation and video generation complete.")
 
-@st.cache_data(persist=True)
 def generate_image_title(input, concept, medium, image, max_retries, temperature, model, debug=False, reasoning_level = "medium"):
     # o1 takes forever.
     if model[0] in ['o', 'P']:

--- a/lofn/ui.py
+++ b/lofn/ui.py
@@ -161,6 +161,7 @@ class LofnApp:
     def render_sidebar(self):
         st.sidebar.header('Settings')
 
+
         st.session_state['competition_mode'] = st.sidebar.checkbox(
             'Competition Mode', value=st.session_state.get('competition_mode', False)
         )
@@ -324,40 +325,10 @@ class LofnApp:
     def render_image_generation(self):
         self.render_image_main_container()
 
-    def render_progress_dashboard(self):
-        steps = ["Concepts", "Prompts", "Images"]
-        progress = st.session_state.get('progress_step', 0)
-        st.markdown("<div class='progress-dashboard'>", unsafe_allow_html=True)
-        st.progress(progress / len(steps))
-        cols = st.columns(len(steps))
-        for i, step in enumerate(steps):
-            label = f"Step {i+1}: {step}"
-            if progress > i:
-                cols[i].markdown(f"**{label}** :white_check_mark:")
-            elif progress == i:
-                cols[i].markdown(f"**{label}** :arrow_right:")
-            else:
-                cols[i].markdown(label)
-        st.markdown("</div>", unsafe_allow_html=True)
-
-        if st.session_state.get('style_axes'):
-            with st.expander("Style Axes", expanded=False):
-                display_style_axes(st.session_state['style_axes'])
-        if st.session_state.get('creativity_spectrum'):
-            with st.expander("Creativity Spectrum", expanded=False):
-                display_creativity_spectrum(st.session_state['creativity_spectrum'])
-        if st.session_state.get('essence_and_facets_output'):
-            facets = st.session_state['essence_and_facets_output'].get('essence_and_facets', {}).get('facets', [])
-            if facets:
-                with st.expander("Facets", expanded=False):
-                    display_facets(facets)
-        if st.session_state.get('prompts_df') is not None and not st.session_state['prompts_df'].empty:
-            with st.expander("Latest Prompt", expanded=False):
-                st.code(st.session_state['prompts_df'].iloc[0]['Revised Prompts'], language='')
 
     def render_image_main_container(self):
         st.header("Generate Your Art Concept")
-        self.render_progress_dashboard()
+
 
         # The user’s idea. Tying it to session_state so it does not vanish
         st.subheader("Describe Your Idea")
@@ -549,7 +520,8 @@ class LofnApp:
             logger.exception("Error selecting best pairs: %s", e)
             best_pairs = pairs[:min(st.session_state.get('num_best_pairs', 3), len(pairs))]
 
-        for pair in best_pairs:
+        top_n = st.session_state.get('num_best_pairs', 3)
+        for pair in best_pairs[:top_n]:
             self.generate_prompts_for_pair(pair)
 
     def generate_images(self, prompts_df, pair):


### PR DESCRIPTION
## Summary
- remove progress dashboard from sidebar and drop function
- output image metadata as JSON code for easier copying
- uncached `generate_image_title`
- slice top-ranked pairs to `num_best_pairs`

## Testing
- `python -m py_compile lofn/*.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683b321f5c848329ac19922398aa5130