### PR TITLE
Expose generation steps in UI

### DIFF
--- a/lofn/helpers.py
+++ b/lofn/helpers.py
@@ -186,7 +186,8 @@ def get_step_name(process_name, step):
     }
     return steps[process_name][step]
 
-def display_creativity_spectrum(creativity_spectrum):
+def create_creativity_spectrum_chart(creativity_spectrum):
+    """Return a Plotly figure visualising the creativity spectrum."""
     labels = ['literal', 'inventive', 'transformative']
     values = [creativity_spectrum['literal'], creativity_spectrum['inventive'], creativity_spectrum['transformative']]
     colors = ['#1f77b4', '#ff7f0e', '#2ca02c']  # Blue, Orange, Green
@@ -194,52 +195,20 @@ def display_creativity_spectrum(creativity_spectrum):
     fig = go.Figure(data=[go.Pie(labels=labels, values=values, hole=.3, marker_colors=colors)])
     fig.update_layout(
         title_text="Creativity Spectrum",
-        height=300  # Adjust this value to change the height of the chart
+        height=300
     )
+    return fig
+
+def display_creativity_spectrum(creativity_spectrum):
+    """Display only the creativity spectrum chart."""
+    fig = create_creativity_spectrum_chart(creativity_spectrum)
     st.plotly_chart(fig, use_container_width=True)
 
 def display_style_axes(style_axes):
-    st.subheader("Style Axes")
-    
-    # Create the radar chart (as before)
+    """Display only the radar plot of style axes."""
     radar_fig = create_style_axes_chart(style_axes)
-    
-    if style_axes != None:
-        # Create a radial bar chart
-        axes = list(style_axes.keys())
-        values = list(style_axes.values())
-    else:
-        axes = ['None']
-        values = [100]
-    
-    radial_bar_fig = go.Figure()
-
-    radial_bar_fig.add_trace(go.Barpolar(
-        r=values,
-        theta=axes,
-        marker_color=values,
-        marker_cmin=0,
-        marker_cmax=100,
-        marker_colorscale="Viridis",
-        opacity=0.8
-    ))
-
-    radial_bar_fig.update_layout(
-        title_text="Style Axes (Lofn Determined)",
-        polar=dict(
-            radialaxis=dict(range=[0, 100], showticklabels=True, ticks=''),
-            angularaxis=dict(showticklabels=True, ticks='')
-        ),
-        height=500,
-        showlegend=False
-    )
-
-    # Display both charts side by side
-    col1, col2 = st.columns(2)
-    with col1:
-        st.plotly_chart(radar_fig, use_container_width=True, title_text="Style Axes (Used Values)")
-    with col2:
-        st.plotly_chart(radial_bar_fig, use_container_width=True)
+    radar_fig.update_layout(title_text="Style Axes (Used Values)", height=500)
+    st.plotly_chart(radar_fig, use_container_width=True)
 
 def display_facets(facets):
     st.subheader("Facets")
@@ -274,6 +243,17 @@ def create_style_axes_chart(style_axes):
     )
     
     return fig
+
+def display_creativity_and_style_axes(creativity_spectrum, style_axes):
+    """Display creativity spectrum and style axes charts side by side."""
+    col1, col2 = st.columns(2)
+    with col1:
+        fig_creativity = create_creativity_spectrum_chart(creativity_spectrum)
+        st.plotly_chart(fig_creativity, use_container_width=True)
+    with col2:
+        fig_style = create_style_axes_chart(style_axes)
+        fig_style.update_layout(title_text="Style Axes (Used Values)", height=500)
+        st.plotly_chart(fig_style, use_container_width=True)
 
 def display_generation_progress(step, total_steps, process_name):
     progress = st.progress(0)
@@ -323,8 +303,21 @@ def create_mini_dashboard(pairs):
                     st.markdown("---")
     return selected_pairs
 
-def display_temporary_results(title, data, is_dataframe=False):
-    with st.expander(title, expanded=True):
+def display_temporary_results(title, data, is_dataframe=False, expanded=True):
+    """Display short-lived results in an expander.
+
+    Parameters
+    ----------
+    title : str
+        Title of the expander.
+    data : Any
+        Data to render inside the expander. Can be list, dict, or dataframe.
+    is_dataframe : bool, optional
+        If True, render the data as a dataframe.
+    expanded : bool, optional
+        Whether the expander should be expanded initially.
+    """
+    with st.expander(title, expanded=expanded):
         if is_dataframe:
             st.dataframe(data)
         elif isinstance(data, list):

--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -27,8 +27,7 @@ from helpers import (
     send_to_discord,
     parse_output,
     display_facets,
-    display_creativity_spectrum,
-    display_style_axes,
+    display_creativity_and_style_axes,
 )
 import plotly.graph_objects as go
 import random
@@ -1227,12 +1226,16 @@ def generate_concept_mediums(
                 chains, input_text, max_retries, debug, style_axes, creativity_spectrum, model
             )
             if essence_and_facets:
-                if st.session_state.creativity_spectrum is None:
-                    display_creativity_spectrum(essence_and_facets["essence_and_facets"]["creativity_spectrum"])
-                else:
-                    display_creativity_spectrum(st.session_state.creativity_spectrum)
+                spectrum = (
+                    essence_and_facets["essence_and_facets"]["creativity_spectrum"]
+                    if st.session_state.creativity_spectrum is None
+                    else st.session_state.creativity_spectrum
+                )
+                display_creativity_and_style_axes(
+                    spectrum,
+                    essence_and_facets["essence_and_facets"]["style_axes"],
+                )
                 display_facets(essence_and_facets["essence_and_facets"]["facets"])
-                display_style_axes(essence_and_facets["essence_and_facets"]["style_axes"])
             
             # Step 2: Concepts
             status.write("Generating Concepts...")
@@ -1407,12 +1410,16 @@ def generate_music_prompts(
             debug=debug,
             expected_schema = music_facets_schema
         )
-        if st.session_state.creativity_spectrum is None:
-            display_creativity_spectrum(output_essence["essence_and_facets"]["creativity_spectrum"])
-        else:
-            display_creativity_spectrum(st.session_state.creativity_spectrum)
+        spectrum = (
+            output_essence["essence_and_facets"]["creativity_spectrum"]
+            if st.session_state.creativity_spectrum is None
+            else st.session_state.creativity_spectrum
+        )
+        display_creativity_and_style_axes(
+            spectrum,
+            output_essence["essence_and_facets"]["style_axes"],
+        )
         display_facets(output_essence["essence_and_facets"]["facets"])
-        display_style_axes(output_essence["essence_and_facets"]["style_axes"])
 
         gen_chain = (
             ChatPromptTemplate.from_messages([("human", music_creation_prompt)])
@@ -1568,6 +1575,11 @@ def generate_image_prompts(input_text, concept, medium, max_retries, temperature
                 st.write("Artistic Guides:")
                 for i, guide in enumerate(artistic_guides['artistic_guides'], 1):
                     st.write(f"{i}. {guide['artistic_guide']}")
+            display_temporary_results(
+                "Artistic Guides",
+                [g['artistic_guide'] for g in artistic_guides['artistic_guides']],
+                expanded=False,
+            )
 
             # Step 3: Generate Image Prompts
             status.write("Generating Image Prompts...")

--- a/lofn/ui.py
+++ b/lofn/ui.py
@@ -391,6 +391,7 @@ class LofnApp:
                 panel_text = st.session_state.get('custom_panel', '')
                 template = read_prompt('/lofn/prompts/overall_prompt_template.txt')
                 input_text = template.replace('{Meta-Prompt}', meta_prompt['meta_prompt']).replace('{Panel-prompt}', panel_text)
+                display_temporary_results("Meta Prompt", meta_prompt['meta_prompt'], expanded=False)
             st.session_state['prompt_input'] = input_text
             with st.spinner("Generating concepts..."):
                 concepts, style_axes, creativity_spectrum = generate_concept_mediums(


### PR DESCRIPTION
## Summary
- show meta-prompt in the UI when using competition mode
- add compact creativity & style charts
- expose temporary artistic guides while prompts are being generated
- factor plot helpers

## Testing
- `python -m py_compile lofn/*.py`

------
https://chatgpt.com/codex/tasks/task_e_683b36f56a9083299fd00bf5be4ab114