### PR TITLE
Fix JSON parsing artifacts

### DIFF
--- a/lofn/helpers.py
+++ b/lofn/helpers.py
@@ -17,23 +17,27 @@ def read_prompt(file_path):
         return file.read()
 
 
-def extract_json_from_text(output):
-    # Look for JSON within the 'text' field
-    text_pattern = r"'text':\s*'(.*?)\s*(?:(?<!\\)'\s*}|$)"
-    text_match = re.search(text_pattern, output, re.DOTALL)
-    if text_match:
-        text_content = text_match.group(1)
-        # Now look for JSON within the extracted text content
-        json_pattern = r'({.*})'
-        json_match = re.search(json_pattern, text_content, re.DOTALL)
-        if json_match:
-            return json_match.group(1)
-    # If not found in 'text' field, look for JSON in the entire output
-    json_pattern = r'({.*})'
-    json_match = re.search(json_pattern, output, re.DOTALL)
-    if json_match:
-        return json_match.group(1)
-    return None
+def extract_json_from_text(output: str) -> Union[str, None]:
+    """Extract a JSON object from a language model response."""
+
+    if output is None:
+        return None
+
+    output = output.strip()
+
+    # Look for a fenced code block first
+    block = re.search(r"```(?:json)?\s*(\{[\s\S]*?\})\s*```", output, re.IGNORECASE)
+    if block:
+        return block.group(1)
+
+    # Next try to pull JSON from a 'text' field that contains a JSON string
+    text_field = re.search(r"['\"]text['\"]:\s*['\"](\{[\s\S]*?\})['\"]", output)
+    if text_field:
+        return text_field.group(1)
+
+    # Fallback to the first JSON-looking snippet
+    match = re.search(r"\{[\s\S]*\}", output)
+    return match.group(0) if match else None
 
 def repair_json(json_string):
     try:
@@ -43,20 +47,24 @@ def repair_json(json_string):
         return json_string
 
 def clean_json_string(json_string):
+    """Lightly clean a JSON string extracted from a response."""
+
     if json_string is None:
         return None
-    # Remove newlines and extra backslashes
-    json_string = json_string.replace('\\n', '').replace('\\\\', '\\')
-    # Remove leading/trailing whitespace
+
     json_string = json_string.strip()
-    # Replace remaining escaped quotes and clean up any leftover single quotes or backslashes
-    json_string = json_string.replace('\\"', '"').replace("'", "").replace("\\", "'")
-    json_pattern = r'({.*})'
-    json_match = re.search(json_pattern, json_string, re.DOTALL)
-    if json_match:
-        return json_match.group(1)
-    else:
-        return json_string
+
+    # Remove Markdown fences if they slipped through
+    json_string = re.sub(r"^```(?:json)?", "", json_string, flags=re.IGNORECASE)
+    json_string = re.sub(r"```$", "", json_string)
+
+    # Keep only the content between the first opening and last closing brace
+    start = json_string.find("{")
+    end = json_string.rfind("}")
+    if start != -1 and end != -1 and start < end:
+        json_string = json_string[start:end + 1]
+
+    return json_string
 
 def parse_output(output, expected_schema, debug=False):
     try:

--- a/tests/test_json_parsing.py
+++ b/tests/test_json_parsing.py
@@ -1,0 +1,46 @@
+import sys
+import os
+import types
+
+# Stub dependencies not available in the test environment
+sys.modules['streamlit'] = types.SimpleNamespace(write=lambda *a, **k: None, code=lambda *a, **k: None)
+sys.modules['requests'] = types.SimpleNamespace(post=lambda *a, **k: None)
+sys.modules['json_repair'] = types.SimpleNamespace(repair_json=lambda s: s)
+
+plotly_module = types.ModuleType("plotly")
+graph_objects_module = types.ModuleType("plotly.graph_objects")
+plotly_module.graph_objects = graph_objects_module
+sys.modules['plotly'] = plotly_module
+sys.modules['plotly.graph_objects'] = graph_objects_module
+
+# Make repository root importable so ``lofn`` becomes a package
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, REPO_ROOT)
+
+# Ensure ``config`` module resolves to ``lofn.config``
+import importlib
+config_module = importlib.import_module('lofn.config')
+sys.modules['config'] = config_module
+
+from lofn.helpers import parse_output
+
+
+def test_preserve_newlines_and_quotes():
+    output = "{'text': '{\"lyrics\": \"line1\\nline2\"}'}"
+    data, error = parse_output(output, {'lyrics': str})
+    assert error is None
+    assert data == {'lyrics': 'line1\nline2'}
+
+
+def test_extract_json_from_markdown_block():
+    output = 'Here is data:\n```json\n{"song": "Can\'t Stop"}\n```\nDone.'
+    data, error = parse_output(output, {'song': str})
+    assert error is None
+    assert data == {'song': "Can't Stop"}
+
+
+def test_trailing_text_ignored():
+    output = '{"foo": "bar"}\nSome trailing text.'
+    data, error = parse_output(output, {'foo': str})
+    assert error is None
+    assert data == {'foo': 'bar'}


### PR DESCRIPTION
## Summary
- make JSON extraction tolerant of Markdown blocks and preserve quoting
- keep JSON string intact when cleaning
- add tests covering newline and quote handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844d8f606c88329af3aff37b9c7193b