### PR TITLE
Add dynamic artistic frame sampling

### DIFF
--- a/lofn/helpers.py
+++ b/lofn/helpers.py
@@ -6,6 +6,7 @@ import streamlit as st
 import requests
 import random
 import json_repair
+import csv
 from typing import Union, List
 from datetime import datetime
 import os
@@ -15,6 +16,21 @@ import plotly.graph_objects as go
 def read_prompt(file_path):
     with open(file_path, "r") as file:
         return file.read()
+
+
+def sample_artistic_frames(min_count: int = 40, max_count: int = 50) -> str:
+    """Return a newline-separated list of randomly selected artistic frames."""
+    with open('/lofn/prompts/frames.csv', newline='') as csvfile:
+        reader = csv.DictReader(csvfile)
+        rows = list(reader)
+
+    count = random.randint(min_count, max_count)
+    sampled = random.sample(rows, count)
+    frames = [
+        f"{row['Category']}{row['Technique']}{row['Description']}"
+        for row in sampled
+    ]
+    return "\n".join(frames)
 
 
 def extract_json_from_text(output: str) -> Union[str, None]:

--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -28,6 +28,7 @@ from helpers import (
     parse_output,
     display_facets,
     display_creativity_and_style_axes,
+    sample_artistic_frames,
 )
 import plotly.graph_objects as go
 import random
@@ -1476,6 +1477,7 @@ def generate_music_prompts(
 
 def generate_meta_prompt(input_text, max_retries, temperature, model="gpt-3.5-turbo-16k", debug=False, reasoning_level="medium"):
     try:
+        frames_list = sample_artistic_frames()
         llm = get_llm(model, temperature, Config.OPENAI_API, Config.ANTHROPIC_API, debug, reasoning_level)
         if model[0] == "o":
             chain = (
@@ -1489,9 +1491,9 @@ def generate_meta_prompt(input_text, max_retries, temperature, model="gpt-3.5-tu
             )
 
         parsed_output = run_llm_chain(
-            {'meta': chain}, 'meta', {'input': input_text}, max_retries, model, debug, expected_schema=meta_prompt_schema
+            {'meta': chain}, 'meta', {'input': input_text, 'frames_list': frames_list}, max_retries, model, debug, expected_schema=meta_prompt_schema
         )
-        return parsed_output
+        return parsed_output, frames_list
     except Exception as e:
         logger.exception("Error generating meta prompt: %s", e)
         raise e

--- a/lofn/prompts/meta_prompt_generation.txt
+++ b/lofn/prompts/meta_prompt_generation.txt
@@ -94,6 +94,9 @@ The primary focus should be an emotional punch that fuses mystique and resonance
 ### Competition Text
 {input}
 
+### Artistic Frames
+{frames_list}
+
 ### Instructions
 - Craft a new meta-prompt in the same spirit as the example.
 - Integrate the competition text seamlessly, keeping language vivid and inspirational.

--- a/lofn/prompts/overall_prompt_template.txt
+++ b/lofn/prompts/overall_prompt_template.txt
@@ -42,43 +42,7 @@ No major changes, just focus on capturing my request without adding new elements
   - For each final medium, list at least 5 distinct composition or stylistic techniques to elevate uniqueness (use your advanced composition guide or the following feeding methods to help come up with ideas):
   - Framing Methods: use an advanced framing method by choosing one of the following, making it more specific by specializing it further, choosing an art style or culture's framing, or choosing to blend a framing with your medium:
 ```tab-delim
-CategoryTechniqueDescription
-AbstractContour Outline BandsConcentric outlines that mimic topographic or ring-like shapes
-Light PlayBinary Light DotsSmall on/off light points arranged systematically near borders
-Mandala WorldsOrnate Circular LabyrinthA labyrinthine circle reminiscent of ancient designs
-Subterranean MythsWorm Tunnel SpiralsStrange, winding tunnels reminiscent of giant burrowing creatures
-AbstractTexture BorderUsing material textures as frame elements
-Embodied DreamsTorso Landscape MergeRolling hills that blend seamlessly into a reclining torso
-Light PlayFiber Optic EdgeLight-conducting materials as frame borders
-Silent CinematicClapperboard CornersOld-fashioned clapperboards at diagonal corners
-Paleo-FuturisticFlint and PlasmaGlowing plasma rods used with flint-like shards forming the border
-Dream CollisionsPillow Castle TurretsFluffy castle towers made of pillow-like materials
-Human ElementsPortrait ProfileUsing facial profiles as side frames
-Mythical CyberpunkCyber Oni MaskA futuristic demon mask with glowing circuit lines at the top corners
-Silent CinematicSepia Tonal VignetteA subtle brownish fade reminiscent of early cinema
-Silent CinematicSilent Title CardsStylized black title cards at the top and bottom corners
-Vector StyleGeometric BreakdownDeconstructed geometric frame elements
-Arcane RunesSpiral Sigil ChainsLinked sigils spiraling from each corner, weaving together
-PolyptychNested TriptychFrames within frames in three sections
-Paleo-FuturisticStone Wheel CircuitPrimitive stone wheels with embedded circuit lines
-Human ElementsPortrait ProfileUsing facial profiles as side frames
-Experimental ExpressionMelanin Print TransferSkin-contact prints forming unique organic textures
-Spiral BiomesVolcanic TwisterAsh and fire swirling in a tornado-like pattern at the edges
-Folk Art RevivalFloral Embroidery BandColorful embroidered flowers running across the edges
-Light PlayOverhead Candle GlowSuspending candles above so that soft flickering glows outline the top
-Human ElementsEye ReflectionUsing eye close-ups as natural frames
-Magical RealismLiving Book PagesPages flipping outward forming a literary vortex around the edges
-CompositeRipped Painting LayersSimulating torn edges of multiple painted canvases
-Light TechniquesLens Flare FrameUsing controlled lens flare as frame elements
-Twisted CartographyCompass Needle OrbitMultiple needle tips rotating around the center in elliptical paths
-Embodied DreamsOneiric Window GazeA window with a giant blinking eye peering inward
-Human ElementsGroup CircleUsing circular human formations as frames
-Arcane RunesOrbital Rune RingsConcentric rings of magical glyphs orbiting the central space
-Cyber BaroqueAugmented Reality GarlandA wearable digital garland overlay that frames the subject in ornate code patterns
-Ancient AlgorithmClay Tablet CodeCuneiform-like inscriptions arranged in meticulous columns
-Mythical CyberpunkUrban Katana ShardSlivers of a digital blade glitching in from corners
-Human ElementsJoined Arms ArchMultiple arms raised and interlinked overhead to create an arch
-Fragmented RealitiesTriple Exposure GatesThree overlapping doorways from different realities
+{frames_list}
 ```
 
 # Artistic Guide Writing, Prompt Writing, and All Refinement Phases

--- a/lofn/ui.py
+++ b/lofn/ui.py
@@ -396,7 +396,7 @@ class LofnApp:
             st.session_state['progress_step'] = 0
             input_text = st.session_state['input']
             if st.session_state.get('competition_mode'):
-                meta_prompt = generate_meta_prompt(
+                meta_prompt, frames_list = generate_meta_prompt(
                     st.session_state.get('input', ''),
                     max_retries=self.max_retries,
                     temperature=self.temperature,
@@ -406,7 +406,11 @@ class LofnApp:
                 )
                 panel_text = st.session_state.get('custom_panel', '')
                 template = read_prompt('/lofn/prompts/overall_prompt_template.txt')
-                input_text = template.replace('{Meta-Prompt}', meta_prompt['meta_prompt']).replace('{Panel-prompt}', panel_text)
+                input_text = (
+                    template.replace('{Meta-Prompt}', meta_prompt['meta_prompt'])
+                    .replace('{Panel-prompt}', panel_text)
+                    .replace('{frames_list}', frames_list)
+                )
                 display_temporary_results("Meta Prompt", meta_prompt['meta_prompt'], expanded=False)
             st.session_state['prompt_input'] = input_text
             with st.spinner("Generating concepts..."):
@@ -569,7 +573,7 @@ class LofnApp:
 
     def run_music_competition(self):
         try:
-            meta_prompt = generate_meta_prompt(
+            meta_prompt, frames_list = generate_meta_prompt(
                 st.session_state.get('input', ''),
                 max_retries=self.max_retries,
                 temperature=self.temperature,
@@ -579,7 +583,11 @@ class LofnApp:
             )
             panel_text = st.session_state.get('custom_panel', '')
             template = read_prompt('/lofn/prompts/overall_prompt_template.txt')
-            input_text = template.replace('{Meta-Prompt}', meta_prompt['meta_prompt']).replace('{Panel-prompt}', panel_text)
+            input_text = (
+                template.replace('{Meta-Prompt}', meta_prompt['meta_prompt'])
+                .replace('{Panel-prompt}', panel_text)
+                .replace('{frames_list}', frames_list)
+            )
             display_temporary_results("Meta Prompt", meta_prompt['meta_prompt'], expanded=False)
             with st.spinner("Generating music prompts..."):
                 music_prompt, lyrics_prompt = generate_music_prompts(


### PR DESCRIPTION
## Summary
- insert placeholder for frame list in overall and meta prompt templates
- randomize list of 40-50 frames from `frames.csv`
- expose new helper `sample_artistic_frames`
- inject frames list into meta prompt generation and UI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844ef13e3a48329aaf85d87d495be18