### PR TITLE
Improve JSON cleaning

### DIFF
--- a/lofn/helpers.py
+++ b/lofn/helpers.py
@@ -62,22 +62,42 @@ def repair_json(json_string):
         st.write(f"Failed to repair JSON: {e}")
         return json_string
 
-def remove_newlines_outside_quotes(s: str) -> str:
-    """Remove newline and carriage return characters that are not within quotes."""
+def normalize_quotes(s: str) -> str:
+    """Replace curly quotes with straight quotes for valid JSON."""
+    replacements = {
+        "“": '"',
+        "”": '"',
+        "‘": "'",
+        "’": "'",
+        "«": '"',
+        "»": '"',
+    }
+    for old, new in replacements.items():
+        s = s.replace(old, new)
+    return s
+
+def remove_escapes_outside_quotes(s: str) -> str:
+    """Remove newline and tab escape sequences that appear outside quoted strings."""
     result = []
     in_quote = False
-    escape = False
-    for ch in s:
-        if ch == '"' and not escape:
+    i = 0
+    while i < len(s):
+        ch = s[i]
+        if ch == '"' and (i == 0 or s[i-1] != '\\'):
             in_quote = not in_quote
-        if ch == '\\' and not escape:
-            escape = True
-        else:
-            escape = False
-        if ch in ('\n', '\r') and not in_quote:
+            result.append(ch)
+            i += 1
+            continue
+        if not in_quote and ch == '\\' and i + 1 < len(s) and s[i+1] in 'nrt':
+            i += 2
+            continue
+        if not in_quote and ch in ('\n', '\r', '\t'):
+            i += 1
             continue
         result.append(ch)
+        i += 1
     return ''.join(result)
+
 
 def clean_json_string(json_string):
     """Lightly clean a JSON string extracted from a response."""
@@ -87,8 +107,11 @@ def clean_json_string(json_string):
 
     json_string = json_string.strip()
 
-    # Remove newline characters that aren't inside quotes
-    json_string = remove_newlines_outside_quotes(json_string)
+    # Normalize fancy quotes before further cleaning
+    json_string = normalize_quotes(json_string)
+
+    # Remove escape sequences and stray newlines outside of quotes
+    json_string = remove_escapes_outside_quotes(json_string)
 
     # Remove Markdown fences if they slipped through
     json_string = re.sub(r"^```(?:json)?", "", json_string, flags=re.IGNORECASE)

--- a/tests/test_json_parsing.py
+++ b/tests/test_json_parsing.py
@@ -44,3 +44,10 @@ def test_trailing_text_ignored():
     data, error = parse_output(output, {'foo': str})
     assert error is None
     assert data == {'foo': 'bar'}
+
+
+def test_curly_quotes_and_escapes_removed():
+    output = 'Intro {“foo”: “bar”, “num”: 3,\n"extra": 1}\nMore'
+    data, error = parse_output(output, {'foo': str, 'num': int, 'extra': int})
+    assert error is None
+    assert data == {'foo': 'bar', 'num': 3, 'extra': 1}


### PR DESCRIPTION
## Summary
- add quote normalization and escape removal helpers
- clean extraneous escapes when parsing JSON
- test cleaning of curly quotes and stray escapes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684522ead2748329a375db3df8576485