### PR TITLE
Add dynamic panel generation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Lofn is an open-source advanced AI art generator that utilizes cutting-edge natu
 - **Discord Integration**: Send generated prompts directly to a Discord channel for seamless use with platforms like Midjourney.
 - **Ethical AI Art Generation**: Incorporates guidelines to ensure ethically generated content respecting cultural sensitivities.
 - **Competition Mode**: Provides streamlined prompts and caption-only output for entering art contests.
+- **LLM-Generated Panels**: Default option automatically crafts expert panels using the chosen language model, while still allowing predefined or custom panels.
 - **Phase Map Guidance**: All generation modes now include a visible "LOFN Master Phase Map" outlining each processing step.
 
 ## Installation

--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -69,6 +69,7 @@ dalle3_gen_prompt_middle = read_prompt('/lofn/prompts/dalle3_gen_prompt.txt')
 dalle3_gen_prompt_nodiv_middle = read_prompt('/lofn/prompts/dalle3_gen_nodiv_prompt.txt')
 meta_prompt_generation_prompt = read_prompt('/lofn/prompts/meta_prompt_generation.txt')
 pair_selection_prompt = read_prompt('/lofn/prompts/pair_selection_prompt.txt')
+panel_generation_prompt = read_prompt('/lofn/prompts/panel_generation_prompt.txt')
 
 # Video prompts
 video_concept_header_part1 = read_prompt('/lofn/prompts/concept_header.txt')
@@ -159,6 +160,10 @@ prompt_configs = {
 
 meta_prompt_schema = {
     'meta_prompt': str
+}
+
+panel_prompt_schema = {
+    'panel_prompt': str
 }
 
 essence_and_facets_schema = {
@@ -1496,6 +1501,29 @@ def generate_meta_prompt(input_text, max_retries, temperature, model="gpt-3.5-tu
         return parsed_output, frames_list
     except Exception as e:
         logger.exception("Error generating meta prompt: %s", e)
+        raise e
+
+def generate_panel_prompt(input_text, max_retries, temperature, model="gpt-3.5-turbo-16k", debug=False, reasoning_level="medium"):
+    """Generate an artistic panel description via the LLM."""
+    try:
+        llm = get_llm(model, temperature, Config.OPENAI_API, Config.ANTHROPIC_API, debug, reasoning_level)
+        if model[0] == "o":
+            chain = (
+                ChatPromptTemplate.from_messages([("human", panel_generation_prompt)])
+                | llm
+            )
+        else:
+            chain = (
+                ChatPromptTemplate.from_messages([("system", concept_system), ("human", panel_generation_prompt)])
+                | llm
+            )
+
+        parsed_output = run_llm_chain(
+            {"panel": chain}, "panel", {"input": input_text}, max_retries, model, debug, expected_schema=panel_prompt_schema
+        )
+        return parsed_output.get("panel_prompt", "")
+    except Exception as e:
+        logger.exception("Error generating panel prompt: %s", e)
         raise e
 
 def select_best_pairs(input_text, pairs, num_best_pairs, max_retries, temperature, model="gpt-3.5-turbo-16k", debug=False, reasoning_level="medium"):

--- a/lofn/prompts/panel_generation_prompt.txt
+++ b/lofn/prompts/panel_generation_prompt.txt
@@ -1,0 +1,19 @@
+You are a panel curator creating an artistic panel tailored to the user's request below. Propose a short list of Special Flairs, a Concept Panel, and a Medium Panel. Favor obscure but real artists. Conclude with one devil's advocate in the Concept Panel.
+
+Return only JSON with the field "panel_prompt" containing a single formatted string with the following structure:
+```
+## Special Flairs:
+1. Flair one
+...
+15. Flair fifteen
+
+## Concept Panel:
+1. **Artist Name** – brief descriptor
+...
+6. **Artist Name (Devil's Advocate)** – brief descriptor
+
+## Medium Panel:
+1. **Artist Name** – brief descriptor
+...
+6. **Artist Name** – brief descriptor
+```

--- a/lofn/ui.py
+++ b/lofn/ui.py
@@ -19,6 +19,8 @@ logger = logging.getLogger(__name__)
 with open('/lofn/prompts/panels.yaml', 'r') as f:
     PANEL_OPTIONS = yaml.safe_load(f)
 
+PANEL_OPTIONS = [{'name': 'LLM Generated', 'prompt': ''}] + PANEL_OPTIONS
+
 class LofnError(Exception):
     """Custom exception class for Lofn-specific errors."""
     pass
@@ -185,6 +187,8 @@ class LofnApp:
                 st.session_state['custom_panel'] = st.sidebar.text_area(
                     'Custom Panel Prompt', value=st.session_state.get('custom_panel', ''), height=150
                 )
+            elif st.session_state['selected_panel'] == 'LLM Generated':
+                st.sidebar.info('Panel will be generated automatically.')
             else:
                 st.session_state['custom_panel'] = next(p['prompt'] for p in PANEL_OPTIONS if p['name'] == st.session_state['selected_panel'])
             st.session_state['num_best_pairs'] = st.sidebar.number_input(
@@ -405,7 +409,21 @@ class LofnApp:
                     debug=self.debug,
                     reasoning_level=st.session_state.get('reasoning_level', 'medium'),
                 )
-                panel_text = st.session_state.get('custom_panel', '')
+                if st.session_state.get('selected_panel') == 'LLM Generated':
+                    if not st.session_state.get('custom_panel'):
+                        panel_text = generate_panel_prompt(
+                            st.session_state.get('input', ''),
+                            self.max_retries,
+                            self.temperature,
+                            self.model,
+                            self.debug,
+                            st.session_state.get('reasoning_level', 'medium')
+                        )
+                        st.session_state['custom_panel'] = panel_text
+                    else:
+                        panel_text = st.session_state.get('custom_panel', '')
+                else:
+                    panel_text = st.session_state.get('custom_panel', '')
                 template = read_prompt('/lofn/prompts/overall_prompt_template.txt')
                 input_text = (
                     template.replace('{Meta-Prompt}', meta_prompt['meta_prompt'])
@@ -582,7 +600,21 @@ class LofnApp:
                 debug=self.debug,
                 reasoning_level=st.session_state.get('reasoning_level', 'medium'),
             )
-            panel_text = st.session_state.get('custom_panel', '')
+            if st.session_state.get('selected_panel') == 'LLM Generated':
+                if not st.session_state.get('custom_panel'):
+                    panel_text = generate_panel_prompt(
+                        st.session_state.get('input', ''),
+                        self.max_retries,
+                        self.temperature,
+                        self.model,
+                        self.debug,
+                        st.session_state.get('reasoning_level', 'medium')
+                    )
+                    st.session_state['custom_panel'] = panel_text
+                else:
+                    panel_text = st.session_state.get('custom_panel', '')
+            else:
+                panel_text = st.session_state.get('custom_panel', '')
             template = read_prompt('/lofn/prompts/overall_prompt_template.txt')
             input_text = (
                 template.replace('{Meta-Prompt}', meta_prompt['meta_prompt'])


### PR DESCRIPTION
## Summary
- allow the concept model to generate a panel prompt on demand
- set "LLM Generated" panels as the default option in the UI
- add prompt template to instruct panel generation
- mention new feature in documentation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847421587708329879d2b21a265ba76