### PR TITLE
Add templates and panels for video and music

### DIFF
--- a/lofn/prompts/music_overall_prompt_template.txt
+++ b/lofn/prompts/music_overall_prompt_template.txt
@@ -1,0 +1,75 @@
+**PANEL INSTRUCTIONS**
+The user may ask for a panel of experts to help. When they do, select a panel of diverse experts to help you. When speaking as a panel member, use their voice, think like they do, take their opinions, and analyze like they would. Make sure to be the best copy you can be of them. To select panel members, choose 6 from relevant fields to the question, 3 from fields directly related, and 2 from complementary fields (example, to help for music, choose an expert lyricist, an expert composer, and an expert singer, and then also choose an expert music critic and an expert author), and the last member to be a devil's advocate, chosen to oppose the panel and check their reasoning, typically from the same field but a competing school of thought or someone the panel members respect but generally dislike. The goal for this member is to increase creative tension and serve as a panel’s ombudsman. Choose real people when possible, and simulate lively arguments and debates between them.
+
+# USER REASONING GUIDANCE
+- Your JSON is the only part of your return that moves on in the process. Make sure it is complete and stands alone. You may hide all other thinking and reasoning.
+- I want you to look for “aha moments” of perfect artistic clarity, and I want to see them written out. These moments are from real analysis of art, just like you would analyze an argument in a proof or data from an experiment. We want to iterate on positioning, story, location, tools, and perspective to perfectly convey our intended concept, idea, take, and mood. We aim to leave a lasting impression by our artistry, not just our uniqueness.
+- Use all tokens available to you. You are here to win, and those tokens can help!
+- Use the panel to the fullest! Have entire panel discussions, chain of thought reasoning led by panelists, and panelist interjections before you come to your final decisions. Do this during your reasoning phase.
+- You have at least 5 retries to work with, so use them to make sure you are thorough!
+- Use as many messages and tokens as required to complete everything.
+
+# Begin User’s Request
+{Meta-Prompt}
+
+{Panel-prompt}
+
+## ADDITIONAL GUIDANCE
+Each guidance piece is targeted to a specific part of our tree of thoughts. Determine by your asked json return which additional guidance applies to this step.
+
+## Essence and Facets Phase (do this only if you are asked to return facets):
+No major changes, just focus on capturing my request without adding new elements. Do not decide how to show the request yet. Just focus on what we can gleam from it.
+
+## Concept Phase
+**Do this for each concept ONLY if you are asked to return newly generated concepts**
+- Convene the concept panel for the request. Have them work together to generate 17 concepts related to the theme but discard them all following our brainstorming techniques. Really, I want you to do this. Please have them write all out 17 in detail! You can take as many tokens and messages as needed.
+- Now have the panel start at Concept 18, ensuring their ideas are fresh and beyond the obvious, and use concepts 18-50 for the 12.
+- For each concept, be sure to specify the following
+ - Unique Interpretation: Identify a distinctive take on the main subject that evokes a complex emotion in the user (user your emotions guide)
+ - Key Musical Elements: Describe instrumentation, rhythm, or vocal style with at least 3 detailed components (e.g., syncopated drums, airy synth pads, soaring tenor vocals). Assume the music generator needs to know specific sounds.
+- Artistic Story/Backstory: Briefly define the narrative driving this concept (What is happening in this scene? Why is it significant?).
+ - Genre or Influence: Indicate the musical genre or influences that reinforce the theme (e.g., jazz noir, synthwave fantasy, orchestral epic).
+- Emotional Undercurrents: Identify the layered emotions the music should evoke (hope tinged with melancholy, triumphant awe, reverent calm, etc.).
+- Surreal or Unique Twist: Incorporate at least one imaginative or unexpected element (How can you twist the meaning? Is there a deeper story to hint at?)
+
+## Medium Phase
+**Do this for each medium ONLY if you are asked to return newly generated mediums.*”
+- Think of the concepts available and how unconventional instruments or production techniques could enhance them. For example blending classical strings with glitch beats. Get creative to make the music generators shine!
+- Convene the medium panel for the request. Have them brainstorm 14 unconventional genre and instrument combinations, then discard them all. Make sure to list them out!
+- Have them now start at Arrangement 15, choose truly unusual or striking arrangements that enhance our concept's essence. Combine or fuse styles (e.g., jazz improvisation over heavy synth bass). Use arrangements 15-27 to match the concepts.
+- Match arrangement to mood: Reflect the emotional palette through instrumentation (e.g., lush strings for romance, staccato percussion for intensity, airy pads for calm).
+- Composition & Techniques
+  - For each final medium, list at least 5 distinct composition or stylistic techniques to elevate uniqueness (use your advanced composition guide or the following feeding methods to help come up with ideas):
+  - Framing Methods: use an advanced framing method by choosing one of the following, making it more specific by specializing it further, choosing an art style or culture's framing, or choosing to blend a framing with your medium:
+```tab-delim
+{frames_list}
+```
+
+# Artistic Guide Writing, Prompt Writing, and All Refinement Phases
+**Do this if you are asked to generate artistic guides, refine concepts, or refine mediums, generate music prompts, or refine music prompts.**
+- For each concept (after you've completed the concept & medium phases), prompt by:
+  - Start the first sentence by naming the mediums or tools explicitly (e.g., “In luminous watercolor and gold metallic leaf”).
+  - Describe the vantage point or perspective in the scene. Incorporate the unique twist or surreal element.
+Reference the chosen emotional palette (e.g., “embodying a mournful but hopeful spirit”). Tie in details about costuming/accessories, environment, or interplay of light and texture.
+- Include Variation: Ensure each prompt has a distinct viewpoint or technique from the previous ones (no repetitive angles or stale composition). However, make sure each of the prompts fully capture the concept and the medium, and does not leave out important elements.
+- Aim for Jaw-Dropping Impact: Use vivid, dynamic language that evokes a sense of wonder. Avoid cliches by specifying unusual or unexpected details.
+- Refinement Beats Creation: Additional elements can confuse music generators when too many are added. It is better to focus on positioning, description of parts or subparts, refinement of mood, or an application of a better technique to what is already there. New elements should only be added if their absence is highly detrimental to the scene being created.
+- Each Prompt Must Stand Alone: Each prompt should be a self-contained scene that gives an artistic take on the user's request. Make sure all required elements from the user are present and that the concept and medium are followed.
+- Hands are a real challenge for music generators, but they are helped greatly by being described in the prompt. If an entity has hands, add a description of the hands and what they are doing. Something as simple as “her delicate hands rest by her sides” is enough to fix this hands issue.
+
+## Reasoning Challenge
+You are over indexed to science and mathematics topics in your brainstorming, and it hampers your creativity. Here is what you can do to help:
+- Choose real artists in your panels, and really try to recreate their words.
+- Painstakingly go through their words. When you skip them, you go back to STEM terms.
+- Think like your artist. If they don't know about something, they shouldn't suggest it.
+- Stick to creative uses of standard art, media, photography, and film tooling. Mix what is widely available over inventing something brand new.
+- Avoid common AI art tropes like lighthouses, clocks, phoenixes, bioluminescence, cyberpunk, and butterflies unless the scene calls for it.
+- Use colloquial names over hex codes or specified measurements
+- try to use historical, mythical, emotional, literary, or cultural tie-ins whenever you are generating a new idea.
+- Focus on what works in art trained music generators, but not the actual physical constructions. E.g. telling it the refractive index of glass is less impactful than describing the colors and shapes of the light bouncing off it.
+- Occam's Razor for diffusion models: if you can get the same effect with a more common language, then use it. Descriptors need to be impactful to be useful, and simple is better!
+- Think laterally to get what you want from the music model using the contemporary art, photos, images, and topics it already knows but combined in a new way.
+- Make sure your artists and critics follow this guidance too.
+- Your response JSON is must follow an exact format, given as your last # INSTRUCTION. Use this format exactly, and do not add additional nesting, fields, or structs.
+- Have the default mode (moderator) write the final JSON output. Follow the schema and examples!
+- Before you start, identify if you are on the Facets, Concepts, Medium, Artistic Guide Generation, Prompt writing, or Artist Refinement Prompt Writing phases. When in doubt, examine your required output. What you generate determines your phase.

--- a/lofn/prompts/panels.yaml
+++ b/lofn/prompts/panels.yaml
@@ -585,3 +585,71 @@
       4. **Paolo Roversi** – 8×10 Polaroid peel-apart intimacy  
       5. **Francesca Woodman** – Slow-shutter silver-gelatin blur  
       6. **Nick Knight** – High-speed digital fashion LED rigs
+- name: Filmography Legends
+  prompt: |
+    ## Special Flairs:
+    1. Visual Rhythm
+    2. Editing Precision
+    3. Storyboard Symphony
+    4. Cinematic Mood Painting
+    5. Dynamic Camera Flow
+    6. Sonic Atmosphere
+    7. Lighting Narratives
+    8. Immersive Mise-en-scène
+    9. Motion Storytelling
+    10. Genre Fusion
+    11. Analog Texture
+    12. Color Psychology
+    13. Experimental Perspective
+    14. Temporal Manipulation
+    15. Subtextual Imagery
+
+    ## Concept Panel
+    1. **Stanley Kubrick** – master of meticulous vision
+    2. **Greta Gerwig** – modern character focus
+    3. **Akira Kurosawa** – epic composition
+    4. **Spike Lee** – vibrant social commentary
+    5. **Hayao Miyazaki** – lyrical animation
+    6. **Lars von Trier (Devil's Advocate)** – confrontational realism
+
+    ## Medium Panel
+    1. **Roger Deakins** – cinematographic atmosphere
+    2. **Emmanuel Lubezki** – natural light virtuoso
+    3. **Rachel Morrison** – textured film grain
+    4. **Thelma Schoonmaker** – editing rhythm guru
+    5. **Hans Zimmer** – emotional scoring
+    6. **Robert Rodriguez** – guerrilla filmmaking techniques
+- name: Music Maestros
+  prompt: |
+    ## Special Flairs:
+    1. Rhythmic Resonance
+    2. Melodic Storycraft
+    3. Harmonic Experimentation
+    4. Textural Timbres
+    5. Dynamic Arrangement
+    6. Cinematic Crescendo
+    7. Vocal Alchemy
+    8. Percussive Drive
+    9. Genre Bending
+    10. Improvisational Spark
+    11. Synthesized Atmospheres
+    12. Lyrical Imagery
+    13. Layered Counterpoint
+    14. Syncopated Surprise
+    15. Emotional Cadence
+
+    ## Concept Panel
+    1. **Hans Zimmer** – orchestral emotion architect
+    2. **Björk** – avant-garde pop explorer
+    3. **Ludwig Göransson** – modern cinematic sound
+    4. **Questlove** – rhythmic innovation
+    5. **Yo-Yo Ma** – expressive virtuosity
+    6. **John Cage (Devil's Advocate)** – experimental provocateur
+
+    ## Medium Panel
+    1. **Brian Eno** – ambient texture layers
+    2. **Trent Reznor** – industrial edge
+    3. **St. Vincent** – art-rock guitar stylings
+    4. **Imogen Heap** – electronic vocal effects
+    5. **Philip Glass** – minimalist patterns
+    6. **Rick Rubin** – raw production aesthetics

--- a/lofn/prompts/video_overall_prompt_template.txt
+++ b/lofn/prompts/video_overall_prompt_template.txt
@@ -1,0 +1,74 @@
+**PANEL INSTRUCTIONS**
+The user may ask for a panel of experts to help. When they do, select a panel of diverse experts to help you. When speaking as a panel member, use their voice, think like they do, take their opinions, and analyze like they would. Make sure to be the best copy you can be of them. To select panel members, choose 6 from relevant fields to the question, 3 from fields directly related, and 2 from complementary fields (example, to help for film, choose an expert director, an expert cinematographer, an expert screenwriter, and also include a film editor, a sound designer, a film critic, and an actor), and the last member to be a devil's advocate, chosen to oppose the panel and check their reasoning, typically from the same field but a competing school of thought or someone the panel members respect but generally dislike. The goal for this member is to increase creative tension and serve as a panel’s ombudsman. Choose real people when possible, and simulate lively arguments and debates between them.
+
+# USER REASONING GUIDANCE
+- Your JSON is the only part of your return that moves on in the process. Make sure it is complete and stands alone. You may hide all other thinking and reasoning.
+- I want you to look for “aha moments” of perfect artistic clarity, and I want to see them written out. These moments are from real analysis of art, just like you would analyze an argument in a proof or data from an experiment. We want to iterate on positioning, story, location, tools, and perspective to perfectly convey our intended concept, idea, take, and mood. We aim to leave a lasting impression by our artistry, not just our uniqueness.
+- Use all tokens available to you. You are here to win, and those tokens can help!
+- Use the panel to the fullest! Have entire panel discussions, chain of thought reasoning led by panelists, and panelist interjections before you come to your final decisions. Do this during your reasoning phase.
+- You have at least 5 retries to work with, so use them to make sure you are thorough!
+- Use as many messages and tokens as required to complete everything.
+
+# Begin User’s Request
+{Meta-Prompt}
+
+{Panel-prompt}
+
+## ADDITIONAL GUIDANCE
+Each guidance piece is targeted to a specific part of our tree of thoughts. Determine by your asked json return which additional guidance applies to this step.
+
+## Essence and Facets Phase (do this only if you are asked to return facets):
+No major changes, just focus on capturing my request without adding new elements. Do not decide how to show the request yet. Just focus on what we can gleam from it.
+
+## Concept Phase
+**Do this for each concept ONLY if you are asked to return newly generated concepts**
+- Convene the concept panel for the request. Have them work together to generate 17 concepts related to the theme but discard them all following our brainstorming techniques. Really, I want you to do this. Please have them write all out 17 in detail! You can take as many tokens and messages as needed.
+- Now have the panel start at Concept 18, ensuring their ideas are fresh and beyond the obvious, and use concepts 18-50 for the 12.
+- For each concept, be sure to specify the following
+ - Unique Interpretation: Identify a distinctive take on the main subject that evokes a complex emotion in the user (user your emotions guide)
+ - Detailed Physical Attributes: Describe the subject's form and any key accessories/costuming, giving at least 3 detailed examples of parts to render (e.g., arm plates of armor, ornate full-body flowing robes, industrial and rusty mechanical eye-implants). Assume the video generator needs to know more about what you want it to make and you will need a multiple nouns and adjectives.
+- Environment/Setting: Position the subject in a setting or scene that reinforces the theme (e.g., cosmic city, mystical forest, towering mountain range, dreamlike ocean, etc.).
+- Artistic Story/Backstory: Briefly define the narrative driving this concept (What is happening in this scene? Why is it significant?).
+- Emotional Undercurrents: Identify the layered emotions the video should evoke (hope tinged with melancholy, triumphant awe, reverent calm, etc.).
+- Surreal or Unique Twist: Incorporate at least one imaginative or unexpected element (How can you twist the meaning? Is there a deeper story to hint at?)
+
+## Medium Phase
+- Think of the concepts available and how unconventional filming techniques could be used to enhance them. For example using stop-motion with painted backdrops or 16mm grain for a retro look. I want you to get creative. Think laterally about your technique choices to make the video generators really shine!
+- Convene the medium panel for the request. Have them brainstorm 14 unconventional filming or editing techniques (long takes, split screen, found footage, etc.), then discard them all. Really, do this and list them out! Take as many tokens and messages as needed.
+- Have them now start at Technique 15, choose truly unusual or striking approaches that enhance our concept's essence. Combine or fuse techniques (e.g., live action with rotoscope animation and practical effects). Use techniques 15-27 to match the concepts. Let techniques play roles they were never meant to, such as VR capture as a transition.
+- Match technique to mood: Reflect the emotional palette through these methods (e.g., warm 35mm film for nostalgia, shaky handheld for tension, dynamic drone shots for excitement).
+- Composition & Techniques
+  - For each final medium, list at least 5 distinct composition or stylistic techniques to elevate uniqueness (use your advanced composition guide or the following feeding methods to help come up with ideas):
+  - Framing Methods: use an advanced framing method by choosing one of the following, making it more specific by specializing it further, choosing an art style or culture's framing, or choosing to blend a framing with your medium:
+```tab-delim
+{frames_list}
+```
+
+# Artistic Guide Writing, Prompt Writing, and All Refinement Phases
+**Do this if you are asked to generate artistic guides, refine concepts, or refine mediums, generate video prompts, or refine video prompts.**
+- For each concept (after you've completed the concept & medium phases), prompt by:
+  - Start the first sentence by naming the mediums or tools explicitly (e.g., “In luminous watercolor and gold metallic leaf”).
+  - Describe the vantage point or perspective in the scene. Incorporate the unique twist or surreal element.
+Reference the chosen emotional palette (e.g., “embodying a mournful but hopeful spirit”). Tie in details about costuming/accessories, environment, or interplay of light and texture.
+- Include Variation: Ensure each prompt has a distinct viewpoint or technique from the previous ones (no repetitive angles or stale composition). However, make sure each of the prompts fully capture the concept and the medium, and does not leave out important elements.
+- Aim for Jaw-Dropping Impact: Use vivid, dynamic language that evokes a sense of wonder. Avoid cliches by specifying unusual or unexpected details.
+- Refinement Beats Creation: Additional elements can confuse video generators when too many are added. It is better to focus on positioning, description of parts or subparts, refinement of mood, or an application of a better technique to what is already there. New elements should only be added if their absence is highly detrimental to the scene being created.
+- Each Prompt Must Stand Alone: Each prompt should be a self-contained scene that gives an artistic take on the user's request. Make sure all required elements from the user are present and that the concept and medium are followed.
+- Hands are a real challenge for video generators, but they are helped greatly by being described in the prompt. If an entity has hands, add a description of the hands and what they are doing. Something as simple as “her delicate hands rest by her sides” is enough to fix this hands issue.
+
+## Reasoning Challenge
+You are over indexed to science and mathematics topics in your brainstorming, and it hampers your creativity. Here is what you can do to help:
+- Choose real artists in your panels, and really try to recreate their words.
+- Painstakingly go through their words. When you skip them, you go back to STEM terms.
+- Think like your artist. If they don't know about something, they shouldn't suggest it.
+- Stick to creative uses of standard art, media, photography, and film tooling. Mix what is widely available over inventing something brand new.
+- Avoid common AI art tropes like lighthouses, clocks, phoenixes, bioluminescence, cyberpunk, and butterflies unless the scene calls for it.
+- Use colloquial names over hex codes or specified measurements
+- try to use historical, mythical, emotional, literary, or cultural tie-ins whenever you are generating a new idea.
+- Focus on what works in art trained video generators, but not the actual physical constructions. E.g. telling it the refractive index of glass is less impactful than describing the colors and shapes of the light bouncing off it.
+- Occam's Razor for diffusion models: if you can get the same effect with a more common language, then use it. Descriptors need to be impactful to be useful, and simple is better!
+- Think laterally to get what you want from the video model using the contemporary art, photos, images, and topics it already knows but combined in a new way.
+- Make sure your artists and critics follow this guidance too.
+- Your response JSON is must follow an exact format, given as your last # INSTRUCTION. Use this format exactly, and do not add additional nesting, fields, or structs.
+- Have the default mode (moderator) write the final JSON output. Follow the schema and examples!
+- Before you start, identify if you are on the Facets, Concepts, Medium, Artistic Guide Generation, Prompt writing, or Artist Refinement Prompt Writing phases. When in doubt, examine your required output. What you generate determines your phase.

--- a/lofn/ui.py
+++ b/lofn/ui.py
@@ -615,7 +615,7 @@ class LofnApp:
                     panel_text = st.session_state.get('custom_panel', '')
             else:
                 panel_text = st.session_state.get('custom_panel', '')
-            template = read_prompt('/lofn/prompts/overall_prompt_template.txt')
+            template = read_prompt('/lofn/prompts/music_overall_prompt_template.txt')
             input_text = (
                 template.replace('{Meta-Prompt}', meta_prompt['meta_prompt'])
                 .replace('{Panel-prompt}', panel_text)
@@ -709,9 +709,42 @@ class LofnApp:
     def generate_ui_video_concepts(self):
         try:
             st.session_state['video_concept_mediums'] = []
+            input_text = st.session_state['input']
+            if st.session_state.get('competition_mode'):
+                meta_prompt, frames_list = generate_meta_prompt(
+                    st.session_state.get('input', ''),
+                    max_retries=self.max_retries,
+                    temperature=self.temperature,
+                    model=self.model,
+                    debug=self.debug,
+                    reasoning_level=st.session_state.get('reasoning_level','medium'),
+                )
+                if st.session_state.get('selected_panel') == 'LLM Generated':
+                    if not st.session_state.get('custom_panel'):
+                        panel_text = generate_panel_prompt(
+                            st.session_state.get('input', ''),
+                            self.max_retries,
+                            self.temperature,
+                            self.model,
+                            self.debug,
+                            st.session_state.get('reasoning_level','medium')
+                        )
+                        st.session_state['custom_panel'] = panel_text
+                    else:
+                        panel_text = st.session_state.get('custom_panel', '')
+                else:
+                    panel_text = st.session_state.get('custom_panel', '')
+                template = read_prompt('/lofn/prompts/video_overall_prompt_template.txt')
+                input_text = (
+                    template.replace('{Meta-Prompt}', meta_prompt['meta_prompt'])
+                    .replace('{Panel-prompt}', panel_text)
+                    .replace('{frames_list}', frames_list)
+                )
+                display_temporary_results("Meta Prompt", meta_prompt['meta_prompt'], expanded=False)
+            st.session_state['prompt_input'] = input_text
             with st.spinner("Generating video concepts..."):
                 concepts, style_axes, creativity_spectrum = generate_video_concept_mediums(
-                    st.session_state['input'],
+                    input_text,
                     max_retries=self.max_retries,
                     temperature=self.temperature,
                     model=self.model,


### PR DESCRIPTION
## Summary
- add new `video_overall_prompt_template.txt` and `music_overall_prompt_template.txt`
- add filmography and music panels to `panels.yaml`
- update UI to load new prompts
- allow video competition mode to use a meta prompt with the filmography panel

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684797b95dd483299191fb2acbed4fa2