### PR TITLE
Revamp panel prompt flow

### DIFF
--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -1521,7 +1521,11 @@ def generate_panel_prompt(input_text, max_retries, temperature, model="gpt-3.5-t
         parsed_output = run_llm_chain(
             {"panel": chain}, "panel", {"input": input_text}, max_retries, model, debug, expected_schema=panel_prompt_schema
         )
-        return parsed_output.get("panel_prompt", "")
+        if parsed_output is not None:
+            return parsed_output.get("panel_prompt", "")
+        else:
+            st.error("Failed to generate or parse panel prompt")
+            return ""
     except Exception as e:
         logger.exception("Error generating panel prompt: %s", e)
         raise e

--- a/lofn/ui.py
+++ b/lofn/ui.py
@@ -401,16 +401,9 @@ class LofnApp:
             st.session_state['progress_step'] = 0
             input_text = st.session_state['input']
             if st.session_state.get('competition_mode'):
-                meta_prompt, frames_list = generate_meta_prompt(
-                    st.session_state.get('input', ''),
-                    max_retries=self.max_retries,
-                    temperature=self.temperature,
-                    model=self.model,
-                    debug=self.debug,
-                    reasoning_level=st.session_state.get('reasoning_level', 'medium'),
-                )
+                panel_text = st.session_state.get('custom_panel', '')
                 if st.session_state.get('selected_panel') == 'LLM Generated':
-                    if not st.session_state.get('custom_panel'):
+                    if not panel_text:
                         panel_text = generate_panel_prompt(
                             st.session_state.get('input', ''),
                             self.max_retries,
@@ -420,10 +413,15 @@ class LofnApp:
                             st.session_state.get('reasoning_level', 'medium')
                         )
                         st.session_state['custom_panel'] = panel_text
-                    else:
-                        panel_text = st.session_state.get('custom_panel', '')
-                else:
-                    panel_text = st.session_state.get('custom_panel', '')
+                    display_temporary_results("Panel Prompt", panel_text, expanded=False)
+                meta_prompt, frames_list = generate_meta_prompt(
+                    st.session_state.get('input', ''),
+                    max_retries=self.max_retries,
+                    temperature=self.temperature,
+                    model=self.model,
+                    debug=self.debug,
+                    reasoning_level=st.session_state.get('reasoning_level', 'medium'),
+                )
                 template = read_prompt('/lofn/prompts/overall_prompt_template.txt')
                 input_text = (
                     template.replace('{Meta-Prompt}', meta_prompt['meta_prompt'])
@@ -592,16 +590,9 @@ class LofnApp:
 
     def run_music_competition(self):
         try:
-            meta_prompt, frames_list = generate_meta_prompt(
-                st.session_state.get('input', ''),
-                max_retries=self.max_retries,
-                temperature=self.temperature,
-                model=self.model,
-                debug=self.debug,
-                reasoning_level=st.session_state.get('reasoning_level', 'medium'),
-            )
+            panel_text = st.session_state.get('custom_panel', '')
             if st.session_state.get('selected_panel') == 'LLM Generated':
-                if not st.session_state.get('custom_panel'):
+                if not panel_text:
                     panel_text = generate_panel_prompt(
                         st.session_state.get('input', ''),
                         self.max_retries,
@@ -611,10 +602,15 @@ class LofnApp:
                         st.session_state.get('reasoning_level', 'medium')
                     )
                     st.session_state['custom_panel'] = panel_text
-                else:
-                    panel_text = st.session_state.get('custom_panel', '')
-            else:
-                panel_text = st.session_state.get('custom_panel', '')
+                display_temporary_results("Panel Prompt", panel_text, expanded=False)
+            meta_prompt, frames_list = generate_meta_prompt(
+                st.session_state.get('input', ''),
+                max_retries=self.max_retries,
+                temperature=self.temperature,
+                model=self.model,
+                debug=self.debug,
+                reasoning_level=st.session_state.get('reasoning_level', 'medium'),
+            )
             template = read_prompt('/lofn/prompts/music_overall_prompt_template.txt')
             input_text = (
                 template.replace('{Meta-Prompt}', meta_prompt['meta_prompt'])
@@ -719,8 +715,9 @@ class LofnApp:
                     debug=self.debug,
                     reasoning_level=st.session_state.get('reasoning_level','medium'),
                 )
+                panel_text = st.session_state.get('custom_panel', '')
                 if st.session_state.get('selected_panel') == 'LLM Generated':
-                    if not st.session_state.get('custom_panel'):
+                    if not panel_text:
                         panel_text = generate_panel_prompt(
                             st.session_state.get('input', ''),
                             self.max_retries,
@@ -730,10 +727,7 @@ class LofnApp:
                             st.session_state.get('reasoning_level','medium')
                         )
                         st.session_state['custom_panel'] = panel_text
-                    else:
-                        panel_text = st.session_state.get('custom_panel', '')
-                else:
-                    panel_text = st.session_state.get('custom_panel', '')
+                    display_temporary_results("Panel Prompt", panel_text, expanded=False)
                 template = read_prompt('/lofn/prompts/video_overall_prompt_template.txt')
                 input_text = (
                     template.replace('{Meta-Prompt}', meta_prompt['meta_prompt'])


### PR DESCRIPTION
## Summary
- handle parsing failures in `generate_panel_prompt`
- move LLM panel generation to happen before meta prompt creation
- display generated panel prompt in a separate expander for image, video and music modes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847a7f486a48329910fd59f019e86db