### PR TITLE
Store music prompts and provide multiple takes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ EXPOSE 8501
 
 RUN mkdir -p /images/
 RUN mkdir -p /metadata/
+RUN mkdir -p /music/
 
 # Use entrypoint script to set environment variables and run Streamlit
 COPY * /lofn/

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Lofn is an open-source advanced AI art generator that utilizes cutting-edge natu
 - **Competition Mode**: Provides streamlined prompts and caption-only output for entering art contests.
 - **LLM-Generated Panels**: Default option automatically crafts expert panels using the chosen language model, while still allowing predefined or custom panels.
 - **Phase Map Guidance**: All generation modes now include a visible "LOFN Master Phase Map" outlining each processing step.
+- **Music Artifacts Saved**: Generated music prompts are automatically stored under `/music`.
 
 ## Installation
 
@@ -74,7 +75,7 @@ To set up Lofn, follow these steps:
 5. **Run the Docker container**:
 
    ```bash
-   docker run -p 8501:8501 -v $(pwd)/images:/images -v $(pwd)/metadata:/metadata lofn
+   docker run -p 8501:8501 -v $(pwd)/images:/images -v $(pwd)/metadata:/metadata -v $(pwd)/music:/music lofn
    ```
 
 6. **Access the Lofn UI**:

--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -35,6 +35,8 @@ import random
 import numpy as np
 import pandas as pd
 import logging
+import os
+from datetime import datetime
 from helpers import display_temporary_results, display_temporary_results_no_expander
 from langchain_core.callbacks.manager import CallbackManagerForLLMRun
 import openai  # For the advanced "o1" usage if needed
@@ -1395,7 +1397,8 @@ def generate_music_prompts(
     temperature,
     model,
     debug=False,
-    reasoning_level="medium"
+    reasoning_level="medium",
+    attempts: int = 1,
 ):
     """
     Generates music prompts based on the user's input.
@@ -1409,7 +1412,8 @@ def generate_music_prompts(
         debug (bool): If True, prints additional debug information.
 
     Returns:
-        tuple: (music_prompt str, lyrics_prompt str)
+        list[dict]: A list of dictionaries with ``title``, ``music_prompt`` and
+        ``lyrics_prompt`` for each attempt.
     """
     try:
         llm = get_llm(model, temperature, Config.OPENAI_API, Config.ANTHROPIC_API, debug, reasoning_level)
@@ -1454,39 +1458,70 @@ def generate_music_prompts(
             | llm
         )
 
-        # Run the chain with retries
-        parsed_output = run_chain_with_retries(
-            gen_chain,
-            args_dict={
-                "input": input_text, 
-                "essence":output_essence["essence_and_facets"]["essence"], 
-                "facets":output_essence["essence_and_facets"]["facets"], 
-                "style_axes":output_essence["essence_and_facets"]["style_axes"],
-                "run_time": run_time},
-            max_retries=max_retries,
-            model=model,
-            debug=debug,
-            expected_schema = music_gen_schema
-        )
-        if debug:
-            print(parsed_output)
-        # Parse the output
-        # parsed_output, error = parse_output(str(gen_output), debug)
-        # if debug:
-        #     print(parsed_output)
-        #     print(error)
-        if parsed_output is not None:
-            music_prompt = parsed_output['music_prompt']
-            lyrics_prompt = parsed_output['lyrics_prompt']
-            music_title = parsed_output['title']
-            return music_prompt, lyrics_prompt, music_title
-        else:
-            st.error(f"Failed to generate or parse music prompts: {error}")
-            return "", ""
+        results = []
+        for attempt in range(attempts):
+            parsed_output = run_chain_with_retries(
+                gen_chain,
+                args_dict={
+                    "input": input_text,
+                    "essence": output_essence["essence_and_facets"]["essence"],
+                    "facets": output_essence["essence_and_facets"]["facets"],
+                    "style_axes": output_essence["essence_and_facets"]["style_axes"],
+                    "run_time": run_time,
+                },
+                max_retries=max_retries,
+                model=model,
+                debug=debug,
+                expected_schema=music_gen_schema,
+            )
+            if debug:
+                print(parsed_output)
+            if parsed_output is not None:
+                music_prompt = parsed_output['music_prompt']
+                lyrics_prompt = parsed_output['lyrics_prompt']
+                music_title = parsed_output['title']
+                result = {
+                    'title': music_title,
+                    'music_prompt': music_prompt,
+                    'lyrics_prompt': lyrics_prompt,
+                }
+                results.append(result)
+                _save_music_artifacts(
+                    {
+                        'timestamp': datetime.now().strftime("%Y%m%d_%H%M%S"),
+                        'model': model,
+                        'user_input': input_text,
+                        'run_time': run_time,
+                        'attempt': attempt + 1,
+                        'essence': output_essence["essence_and_facets"]["essence"],
+                        'facets': output_essence["essence_and_facets"]["facets"],
+                        'style_axes': output_essence["essence_and_facets"]["style_axes"],
+                        'creativity_spectrum': output_essence["essence_and_facets"]["creativity_spectrum"],
+                        **result,
+                    }
+                )
+            else:
+                st.error("Failed to generate or parse music prompts")
+        return results
 
     except Exception as e:
         logger.exception("Error generating music prompts: %s", e)
         raise e
+
+def _save_music_artifacts(data: Dict[str, Any]) -> None:
+    """Persist generated music prompts and metadata under ``/music``."""
+    os.makedirs('/music', exist_ok=True)
+    filename = (
+        f"/music/{data['timestamp']}_{data['model'].replace('/', '_')}_"
+        f"attempt{data['attempt']}.json"
+    )
+    def _json_serializable(obj):
+        if isinstance(obj, datetime):
+            return obj.isoformat()
+        raise TypeError(f"Type {type(obj)} not serializable")
+    with open(filename, 'w') as f:
+        json.dump(data, f, indent=2, default=_json_serializable)
+    st.write(f"Music prompts saved as {filename}")
 
 def generate_meta_prompt(input_text, max_retries, temperature, model="gpt-3.5-turbo-16k", debug=False, reasoning_level="medium"):
     try:

--- a/lofn/ui.py
+++ b/lofn/ui.py
@@ -619,17 +619,16 @@ class LofnApp:
             )
             display_temporary_results("Meta Prompt", meta_prompt['meta_prompt'], expanded=False)
             with st.spinner("Generating music prompts..."):
-                music_title, music_prompt, lyrics_prompt = generate_music_prompts(
+                results = generate_music_prompts(
                     input_text,
                     st.session_state['run_time'],
                     max_retries=self.max_retries,
                     temperature=self.temperature,
                     model=self.model,
                     debug=self.debug,
+                    attempts=3,
                 )
-            st.session_state['music_prompt'] = music_prompt
-            st.session_state['lyrics_prompt'] = lyrics_prompt
-            st.session_state['music_title'] = music_title
+            st.session_state['music_results'] = results
             st.success("Music prompts generated successfully!")
             self.display_music_prompts()
         except Exception as e:
@@ -832,7 +831,7 @@ class LofnApp:
             else:
                 self.run_music_competition()
 
-        if 'music_prompt' in st.session_state and 'lyrics_prompt' in st.session_state:
+        if st.session_state.get('music_results'):
             self.display_music_prompts()
 
     def render_music_sidebar(self):
@@ -851,17 +850,16 @@ class LofnApp:
     def generate_music_prompts_ui(self):
         try:
             with st.spinner("Generating music prompts..."):
-                music_prompt, lyrics_prompt, music_title = generate_music_prompts(
+                results = generate_music_prompts(
                     st.session_state['input'],
                     st.session_state['run_time'],
                     max_retries=self.max_retries,
                     temperature=self.temperature,
                     model=self.model,
                     debug=self.debug,
+                    attempts=3,
                 )
-            st.session_state['music_prompt'] = music_prompt
-            st.session_state['lyrics_prompt'] = lyrics_prompt
-            st.session_state['music_title'] = music_title
+            st.session_state['music_results'] = results
             st.success("Music prompts generated successfully!")
             self.display_music_prompts()
         except Exception as e:
@@ -869,15 +867,14 @@ class LofnApp:
             logger.exception("Error generating music prompts: %s", e)
 
     def display_music_prompts(self):
-        st.subheader("Generated Song Title")
-        st.code(st.session_state['music_title'], language='text')
-
-        st.subheader("Generated Music Prompt")
-        st.code(st.session_state['music_prompt'], language='text')
-
-        st.subheader("Generated Lyrics Prompt")
-        st.code(st.session_state['lyrics_prompt'], language='text')
-        st.info("Copy the above prompts and paste them into Udio to generate your music.")
+        results = st.session_state.get('music_results', [])
+        for i, result in enumerate(results, 1):
+            st.subheader(f"Attempt {i}: {result['title']}")
+            st.code(result['music_prompt'], language='text')
+            st.code(result['lyrics_prompt'], language='text')
+            st.markdown('---')
+        if results:
+            st.info("Copy any of the above prompts into Udio to generate your music.")
 
     def initialize_session_state(self):
         default_values = {
@@ -888,6 +885,7 @@ class LofnApp:
             'music_title': None,
             'music_prompt': None,
             'lyrics_prompt': None,
+            'music_results': None,
             'concept_mediums': None,
             'pairs_to_try': [0],
             'button_clicked': False,


### PR DESCRIPTION
## Summary
- preserve generated music prompts under `/music`
- generate three music prompt attempts in `generate_music_prompts`
- surface multiple music attempts in the Streamlit UI
- document the new `/music` mount and feature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850e4fae6648329aec755911fc5fc01