### PR TITLE
Add genre support for music prompts

### DIFF
--- a/lofn/helpers.py
+++ b/lofn/helpers.py
@@ -42,6 +42,16 @@ def sample_artistic_frames(min_count: int = 40, max_count: int = 50) -> str:
     return "\n".join(frames)
 
 
+def sample_music_genres(min_count: int = 40, max_count: int = 50) -> str:
+    """Return a newline-separated list of randomly selected music genres."""
+    with open('/lofn/prompts/genres.txt', 'r') as file:
+        genres = file.read().split(', ')
+
+    count = random.randint(min_count, max_count)
+    sampled = random.sample(genres, count)
+    return "\n".join(sampled)
+
+
 def extract_json_from_text(output: str) -> Union[str, None]:
     """Extract a JSON object from a language model response."""
 

--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -29,6 +29,7 @@ from helpers import (
     display_facets,
     display_creativity_and_style_axes,
     sample_artistic_frames,
+    sample_music_genres,
 )
 import plotly.graph_objects as go
 import random
@@ -1488,9 +1489,20 @@ def generate_music_prompts(
         logger.exception("Error generating music prompts: %s", e)
         raise e
 
-def generate_meta_prompt(input_text, max_retries, temperature, model="gpt-3.5-turbo-16k", debug=False, reasoning_level="medium"):
+def generate_meta_prompt(
+    input_text,
+    max_retries,
+    temperature,
+    model="gpt-3.5-turbo-16k",
+    debug=False,
+    reasoning_level="medium",
+    medium="image",
+):
     try:
-        frames_list = sample_artistic_frames()
+        if medium == "music":
+            frames_list = sample_music_genres()
+        else:
+            frames_list = sample_artistic_frames()
         llm = get_llm(model, temperature, Config.OPENAI_API, Config.ANTHROPIC_API, debug, reasoning_level)
         if model[0] == "o":
             chain = (
@@ -1503,8 +1515,9 @@ def generate_meta_prompt(input_text, max_retries, temperature, model="gpt-3.5-tu
                 | llm
             )
 
+        key = 'genres_list' if medium == "music" else 'frames_list'
         parsed_output = run_llm_chain(
-            {'meta': chain}, 'meta', {'input': input_text, 'frames_list': frames_list}, max_retries, model, debug, expected_schema=meta_prompt_schema
+            {'meta': chain}, 'meta', {'input': input_text, key: frames_list}, max_retries, model, debug, expected_schema=meta_prompt_schema
         )
         return parsed_output, frames_list
     except Exception as e:

--- a/lofn/prompts/music_overall_prompt_template.txt
+++ b/lofn/prompts/music_overall_prompt_template.txt
@@ -44,7 +44,7 @@ No major changes, just focus on capturing my request without adding new elements
   - For each final medium, list at least 5 distinct composition or stylistic techniques to elevate uniqueness (use your advanced composition guide or the following arrangement approaches to help come up with ideas):
   - Arrangement Approaches: choose one of the following approaches, specialize it further with cultural influences, or blend multiple approaches with your medium:
 ```tab-delim
-{frames_list}
+{genres_list}
 ```
 
 # Artistic Guide Writing, Prompt Writing, and All Refinement Phases

--- a/lofn/ui.py
+++ b/lofn/ui.py
@@ -603,19 +603,20 @@ class LofnApp:
                     )
                     st.session_state['custom_panel'] = panel_text
                 display_temporary_results("Panel Prompt", panel_text, expanded=False)
-            meta_prompt, frames_list = generate_meta_prompt(
+            meta_prompt, genres_list = generate_meta_prompt(
                 st.session_state.get('input', ''),
                 max_retries=self.max_retries,
                 temperature=self.temperature,
                 model=self.model,
                 debug=self.debug,
                 reasoning_level=st.session_state.get('reasoning_level', 'medium'),
+                medium="music",
             )
             template = read_prompt('/lofn/prompts/music_overall_prompt_template.txt')
             input_text = (
                 template.replace('{Meta-Prompt}', meta_prompt['meta_prompt'])
                 .replace('{Panel-prompt}', panel_text)
-                .replace('{frames_list}', frames_list)
+                .replace('{genres_list}', genres_list)
             )
             display_temporary_results("Meta Prompt", meta_prompt['meta_prompt'], expanded=False)
             with st.spinner("Generating music prompts..."):


### PR DESCRIPTION
## Summary
- sample random music genres from a new helper
- choose genres rather than visual frames when generating music prompts
- replace frame placeholder in music prompt template with genres

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856202e803883299bbd18b7dcd1e5c2