### PR TITLE
Add music frames dataset and sampling

### DIFF
--- a/lofn/helpers.py
+++ b/lofn/helpers.py
@@ -52,6 +52,22 @@ def sample_music_genres(min_count: int = 40, max_count: int = 50) -> str:
     return "\n".join(sampled)
 
 
+def sample_music_frames(min_count: int = 40, max_count: int = 50) -> str:
+    """Return a newline-separated list of randomly selected music frames."""
+    path = os.path.join(os.path.dirname(__file__), 'prompts', 'music_frames.csv')
+    with open(path, newline='') as csvfile:
+        reader = csv.DictReader(csvfile)
+        rows = list(reader)
+
+    count = random.randint(min_count, max_count)
+    sampled = random.sample(rows, count)
+    frames = [
+        f"{row['Category']}{row['Technique']}{row['Description']}"
+        for row in sampled
+    ]
+    return "\n".join(frames)
+
+
 def extract_json_from_text(output: str) -> Union[str, None]:
     """Extract a JSON object from a language model response."""
 

--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -29,7 +29,7 @@ from helpers import (
     display_facets,
     display_creativity_and_style_axes,
     sample_artistic_frames,
-    sample_music_genres,
+    sample_music_frames,
 )
 import plotly.graph_objects as go
 import random
@@ -1500,7 +1500,7 @@ def generate_meta_prompt(
 ):
     try:
         if medium == "music":
-            frames_list = sample_music_genres()
+            frames_list = sample_music_frames()
         else:
             frames_list = sample_artistic_frames()
         llm = get_llm(model, temperature, Config.OPENAI_API, Config.ANTHROPIC_API, debug, reasoning_level)

--- a/lofn/prompts/music_frames.csv
+++ b/lofn/prompts/music_frames.csv
@@ -1,0 +1,56 @@
+Category,Technique,Description
+Rhythm,Syncopated Stabs,Short accents hitting off the beat
+Rhythm,Triplet Swing,Swing feel with triplet subdivisions
+Rhythm,Polyrhythmic Layer,Overlapping rhythms of different meters
+Rhythm,Handclap Pulse,Steady handclaps accenting beats
+Rhythm,Stutter Drum Break,Cut-up drum beat for glitchy feel
+Melody,Ascending Riff,Melody that climbs each repetition
+Melody,Descending Scale,Simple scale walk-down motif
+Melody,Call and Response,Two melodic phrases trading off
+Melody,Microtonal Bend,Pitch bending between notes
+Melody,Ostinato Loop,Short repeating melodic figure
+Harmony,Power Chord Drive,Chugging guitar power chords
+Harmony,Cluster Chords,Closely spaced dissonant chords
+Harmony,Modal Shift,Switching modes mid-phrase
+Harmony,Sus4 Resolve,Suspension resolving to major triad
+Harmony,Pedal Drone,Static bass note under chords
+Sound Design,Granular Texture,Fragments of sound reassembled
+Sound Design,Reverse Hit,Reversed sample leading into beat
+Sound Design,Filtered Sweep,Rising filter to accent sections
+Sound Design,Noise Burst,Sudden noise accent for impact
+Sound Design,Analog Warmth,Subtle tape saturation effect
+Dynamics,Gentle Crescendo,Slowly increasing volume
+Dynamics,Big Drop,Silence before strong chorus hit
+Dynamics,Soft Intro,Minimal instrumentation at start
+Dynamics,Layered Climax,Multiple tracks building at peak
+Dynamics,Fermata Hold,Dramatically holding final chord
+Production,Stereo Ping-Pong,Alternating left-right echoes
+Production,Lo-Fi Crunch,Bitcrushed texture for vintage feel
+Production,Sidechain Pump,Synth ducking with kick drum
+Production,Spatial Reverb,Large hall ambience
+Production,Vocoder Harmony,Pitched vocal layers with vocoder
+Experimental,Found Object Percussion,Using everyday objects as drums
+Experimental,Algorithmic Melody,Generative melody lines
+Experimental,Circuit Bent Synth,Glitched electronics
+Experimental,Odd Time Sig,Unusual time signatures
+Experimental,Prepared Piano,Altered piano strings for texture
+Ambient,Droning Pad,Long sustained synth pad
+Ambient,Nature Field Recording,Background ambience from nature
+Ambient,Slow Attack Strings,Gradual swell of string section
+Ambient,Tape Loop Warble,Looped tape with pitch wobble
+Ambient,Ethereal Choir,Wordless choral layers
+Percussion,Shaker Groove,Steady shaker accent
+Percussion,Tom Fill Swells,Rising tom fills between sections
+Percussion,Brush Snare,Soft snare hits with brushes
+Percussion,Body Percussion,Claps and stomps as rhythm
+Percussion,Metallic Hits,Percussive metal objects
+Vocal,Whisper Layer,Soft whispered doubles
+Vocal,Group Chant,Unified crowd vocals
+Vocal,Vocal Fry Ad-libs,Guttural textural additions
+Vocal,Harmony Stack,Multiple harmonies layered
+Vocal,Callout Shouts,Short shouted phrases
+Electronic,Sideband Modulation,Pitch-shifting effect
+Electronic,FM Bell Tone,Metallic synth patch
+Electronic,Chiptune Arp,Retro video game arpeggio
+Electronic,Bass Wobble,LFO-driven bass movement
+Electronic,Granular Stretch,Time-stretched sample

--- a/tests/test_music_frames.py
+++ b/tests/test_music_frames.py
@@ -1,0 +1,31 @@
+import sys
+import os
+import types
+
+# Stub dependencies
+streamlit_stub = types.SimpleNamespace(session_state={})
+sys.modules['streamlit'] = streamlit_stub
+sys.modules['requests'] = types.SimpleNamespace(post=lambda *a, **k: None)
+sys.modules['json_repair'] = types.SimpleNamespace(repair_json=lambda s: s)
+
+plotly_module = types.ModuleType("plotly")
+graph_objects_module = types.ModuleType("plotly.graph_objects")
+plotly_module.graph_objects = graph_objects_module
+sys.modules['plotly'] = plotly_module
+sys.modules['plotly.graph_objects'] = graph_objects_module
+
+# Make repo root importable
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, REPO_ROOT)
+
+import importlib
+config_module = importlib.import_module('lofn.config')
+sys.modules['config'] = config_module
+from lofn.helpers import sample_music_frames
+
+
+def test_sample_music_frames_returns_lines():
+    data = sample_music_frames(min_count=5, max_count=5)
+    lines = data.split('\n')
+    assert len(lines) == 5
+    assert all(line for line in lines)


### PR DESCRIPTION
## Summary
- add a CSV of music frames for use when generating music prompts
- implement `sample_music_frames` helper to read that file
- update LLM integration to use `sample_music_frames`
- add tests covering the new helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856254e1444832991ff4a9bea9f4990