### PR TITLE
Enable music metadata saving and use frames/genres

### DIFF
--- a/lofn/helpers.py
+++ b/lofn/helpers.py
@@ -44,7 +44,8 @@ def sample_artistic_frames(min_count: int = 40, max_count: int = 50) -> str:
 
 def sample_music_genres(min_count: int = 40, max_count: int = 50) -> str:
     """Return a newline-separated list of randomly selected music genres."""
-    with open('/lofn/prompts/genres.txt', 'r') as file:
+    path = os.path.join(os.path.dirname(__file__), 'prompts', 'genres.txt')
+    with open(path, 'r') as file:
         genres = file.read().split(', ')
 
     count = random.randint(min_count, max_count)
@@ -498,3 +499,18 @@ def send_to_discord(content, content_type='prompts', premessage=''):
                     requests.post(st.session_state['webhook_url'], data=json.dumps(message), headers={"Content-Type": "application/json"})
     except Exception as e:
         st.write(f"An error occurred while sending to Discord: {str(e)}")
+
+def save_music_data(metadata):
+    """Save music prompts and metadata to the /music directory."""
+    os.makedirs('/music', exist_ok=True)
+    timestamp = metadata.get('timestamp')
+    if isinstance(timestamp, datetime):
+        timestamp_str = timestamp.strftime('%Y%m%d_%H%M%S')
+    else:
+        timestamp_str = str(timestamp)
+    title_slug = metadata.get('title', 'untitled')[:10].replace(' ', '_')
+    model = metadata.get('model', 'model')[:10].replace('/', '_')
+    filename = f"/music/{timestamp_str}_{model}_{title_slug}.json"
+    with open(filename, 'w') as f:
+        json.dump(metadata, f, indent=2, default=str)
+    st.write(f"Music metadata saved as {filename}")

--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -30,6 +30,7 @@ from helpers import (
     display_creativity_and_style_axes,
     sample_artistic_frames,
     sample_music_frames,
+    sample_music_genres,
 )
 import plotly.graph_objects as go
 import random
@@ -1501,8 +1502,10 @@ def generate_meta_prompt(
     try:
         if medium == "music":
             frames_list = sample_music_frames()
+            genres_list = sample_music_genres()
         else:
             frames_list = sample_artistic_frames()
+            genres_list = None
         llm = get_llm(model, temperature, Config.OPENAI_API, Config.ANTHROPIC_API, debug, reasoning_level)
         if model[0] == "o":
             chain = (
@@ -1515,11 +1518,14 @@ def generate_meta_prompt(
                 | llm
             )
 
-        key = 'genres_list' if medium == "music" else 'frames_list'
+        args = {'input': input_text, 'frames_list': frames_list}
+        if genres_list is not None:
+            args['genres_list'] = genres_list
+
         parsed_output = run_llm_chain(
-            {'meta': chain}, 'meta', {'input': input_text, key: frames_list}, max_retries, model, debug, expected_schema=meta_prompt_schema
+            {'meta': chain}, 'meta', args, max_retries, model, debug, expected_schema=meta_prompt_schema
         )
-        return parsed_output, frames_list
+        return parsed_output, frames_list, genres_list
     except Exception as e:
         logger.exception("Error generating meta prompt: %s", e)
         raise e

--- a/lofn/prompts/music_overall_prompt_template.txt
+++ b/lofn/prompts/music_overall_prompt_template.txt
@@ -46,6 +46,10 @@ No major changes, just focus on capturing my request without adding new elements
 ```tab-delim
 {genres_list}
 ```
+  - Composition Frames: experiment with these rhythmic or melodic frames, combining or adapting them to your arrangement:
+```tab-delim
+{frames_list}
+```
 
 # Artistic Guide Writing, Prompt Writing, and All Refinement Phases
 **Do this if you are asked to generate artistic guides, refine concepts, or refine mediums, generate music prompts, or refine music prompts.**

--- a/lofn/ui.py
+++ b/lofn/ui.py
@@ -1,6 +1,7 @@
 import os
 import logging
 import random
+from datetime import datetime
 import pandas as pd
 import streamlit as st
 import yaml
@@ -414,7 +415,7 @@ class LofnApp:
                         )
                         st.session_state['custom_panel'] = panel_text
                     display_temporary_results("Panel Prompt", panel_text, expanded=False)
-                meta_prompt, frames_list = generate_meta_prompt(
+                meta_prompt, frames_list, _ = generate_meta_prompt(
                     st.session_state.get('input', ''),
                     max_retries=self.max_retries,
                     temperature=self.temperature,
@@ -603,7 +604,7 @@ class LofnApp:
                     )
                     st.session_state['custom_panel'] = panel_text
                 display_temporary_results("Panel Prompt", panel_text, expanded=False)
-            meta_prompt, genres_list = generate_meta_prompt(
+            meta_prompt, frames_list, genres_list = generate_meta_prompt(
                 st.session_state.get('input', ''),
                 max_retries=self.max_retries,
                 temperature=self.temperature,
@@ -617,6 +618,7 @@ class LofnApp:
                 template.replace('{Meta-Prompt}', meta_prompt['meta_prompt'])
                 .replace('{Panel-prompt}', panel_text)
                 .replace('{genres_list}', genres_list)
+                .replace('{frames_list}', frames_list)
             )
             display_temporary_results("Meta Prompt", meta_prompt['meta_prompt'], expanded=False)
             with st.spinner("Generating music prompts..."):
@@ -631,6 +633,17 @@ class LofnApp:
             st.session_state['music_prompt'] = music_prompt
             st.session_state['lyrics_prompt'] = lyrics_prompt
             st.session_state['music_title'] = music_title
+            save_music_data({
+                'timestamp': datetime.utcnow(),
+                'title': music_title,
+                'music_prompt': music_prompt,
+                'lyrics_prompt': lyrics_prompt,
+                'run_time': st.session_state['run_time'],
+                'input': st.session_state['input'],
+                'model': self.model,
+                'style_axes': st.session_state.get('style_axes'),
+                'creativity_spectrum': st.session_state.get('creativity_spectrum'),
+            })
             st.success("Music prompts generated successfully!")
             self.display_music_prompts()
         except Exception as e:
@@ -709,7 +722,7 @@ class LofnApp:
             st.session_state['video_concept_mediums'] = []
             input_text = st.session_state['input']
             if st.session_state.get('competition_mode'):
-                meta_prompt, frames_list = generate_meta_prompt(
+                meta_prompt, frames_list, _ = generate_meta_prompt(
                     st.session_state.get('input', ''),
                     max_retries=self.max_retries,
                     temperature=self.temperature,
@@ -863,6 +876,17 @@ class LofnApp:
             st.session_state['music_prompt'] = music_prompt
             st.session_state['lyrics_prompt'] = lyrics_prompt
             st.session_state['music_title'] = music_title
+            save_music_data({
+                'timestamp': datetime.utcnow(),
+                'title': music_title,
+                'music_prompt': music_prompt,
+                'lyrics_prompt': lyrics_prompt,
+                'run_time': st.session_state['run_time'],
+                'input': st.session_state['input'],
+                'model': self.model,
+                'style_axes': st.session_state.get('style_axes'),
+                'creativity_spectrum': st.session_state.get('creativity_spectrum'),
+            })
             st.success("Music prompts generated successfully!")
             self.display_music_prompts()
         except Exception as e:

--- a/tests/test_music_genres.py
+++ b/tests/test_music_genres.py
@@ -1,0 +1,31 @@
+import sys
+import os
+import types
+
+# Stub dependencies
+streamlit_stub = types.SimpleNamespace(session_state={})
+sys.modules['streamlit'] = streamlit_stub
+sys.modules['requests'] = types.SimpleNamespace(post=lambda *a, **k: None)
+sys.modules['json_repair'] = types.SimpleNamespace(repair_json=lambda s: s)
+
+plotly_module = types.ModuleType("plotly")
+graph_objects_module = types.ModuleType("plotly.graph_objects")
+plotly_module.graph_objects = graph_objects_module
+sys.modules['plotly'] = plotly_module
+sys.modules['plotly.graph_objects'] = graph_objects_module
+
+# Make repo root importable
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, REPO_ROOT)
+
+import importlib
+config_module = importlib.import_module('lofn.config')
+sys.modules['config'] = config_module
+from lofn.helpers import sample_music_genres
+
+
+def test_sample_music_genres_returns_lines():
+    data = sample_music_genres(min_count=5, max_count=5)
+    lines = data.split('\n')
+    assert len(lines) == 5
+    assert all(line for line in lines)


### PR DESCRIPTION
## Summary
- support genres in `generate_meta_prompt`
- add music composition frames to prompt template
- save music prompts with metadata to `/music`
- add test for `sample_music_genres`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68562f837fc88329861c39957c9f737e