### PR TITLE
Support music frames and genre saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ To set up Lofn, follow these steps:
 5. **Run the Docker container**:
 
    ```bash
-   docker run -p 8501:8501 -v $(pwd)/images:/images -v $(pwd)/metadata:/metadata lofn
+   docker run -p 8501:8501 -v $(pwd)/images:/images -v $(pwd)/metadata:/metadata -v $(pwd)/music:/music lofn
    ```
 
 6. **Access the Lofn UI**:

--- a/lofn/helpers.py
+++ b/lofn/helpers.py
@@ -44,7 +44,8 @@ def sample_artistic_frames(min_count: int = 40, max_count: int = 50) -> str:
 
 def sample_music_genres(min_count: int = 40, max_count: int = 50) -> str:
     """Return a newline-separated list of randomly selected music genres."""
-    with open('/lofn/prompts/genres.txt', 'r') as file:
+    path = os.path.join(os.path.dirname(__file__), 'prompts', 'genres.txt')
+    with open(path, 'r') as file:
         genres = file.read().split(', ')
 
     count = random.randint(min_count, max_count)

--- a/lofn/image_generation.py
+++ b/lofn/image_generation.py
@@ -944,5 +944,20 @@ def save_metadata(metadata):
     # Save the metadata as a JSON file
     with open(metadata_filename, 'w') as f:
         json.dump(metadata, f, indent=2, default=json_serializable)
-    
+
     st.write(f"Metadata saved as {metadata_filename}")
+
+
+def save_music_metadata(metadata):
+    os.makedirs('/music', exist_ok=True)
+    metadata_filename = f"/music/{metadata['timestamp']}_{metadata['title'][0:10]}.json"
+
+    def json_serializable(obj):
+        if isinstance(obj, datetime):
+            return obj.isoformat()
+        raise TypeError(f'Type {type(obj)} not serializable')
+
+    with open(metadata_filename, 'w') as f:
+        json.dump(metadata, f, indent=2, default=json_serializable)
+
+    st.write(f"Music metadata saved as {metadata_filename}")

--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -30,6 +30,7 @@ from helpers import (
     display_creativity_and_style_axes,
     sample_artistic_frames,
     sample_music_frames,
+    sample_music_genres,
 )
 import plotly.graph_objects as go
 import random
@@ -1501,8 +1502,10 @@ def generate_meta_prompt(
     try:
         if medium == "music":
             frames_list = sample_music_frames()
+            genres_list = sample_music_genres()
         else:
             frames_list = sample_artistic_frames()
+            genres_list = None
         llm = get_llm(model, temperature, Config.OPENAI_API, Config.ANTHROPIC_API, debug, reasoning_level)
         if model[0] == "o":
             chain = (
@@ -1515,11 +1518,20 @@ def generate_meta_prompt(
                 | llm
             )
 
-        key = 'genres_list' if medium == "music" else 'frames_list'
-        parsed_output = run_llm_chain(
-            {'meta': chain}, 'meta', {'input': input_text, key: frames_list}, max_retries, model, debug, expected_schema=meta_prompt_schema
-        )
-        return parsed_output, frames_list
+        if medium == "music":
+            parsed_output = run_llm_chain(
+                {'meta': chain}, 'meta', {
+                    'input': input_text,
+                    'genres_list': genres_list,
+                    'frames_list': frames_list
+                }, max_retries, model, debug, expected_schema=meta_prompt_schema
+            )
+            return parsed_output, frames_list, genres_list
+        else:
+            parsed_output = run_llm_chain(
+                {'meta': chain}, 'meta', {'input': input_text, 'frames_list': frames_list}, max_retries, model, debug, expected_schema=meta_prompt_schema
+            )
+            return parsed_output, frames_list
     except Exception as e:
         logger.exception("Error generating meta prompt: %s", e)
         raise e

--- a/lofn/prompts/music_overall_prompt_template.txt
+++ b/lofn/prompts/music_overall_prompt_template.txt
@@ -47,6 +47,10 @@ No major changes, just focus on capturing my request without adding new elements
 {genres_list}
 ```
 
+```tab-delim
+{frames_list}
+```
+
 # Artistic Guide Writing, Prompt Writing, and All Refinement Phases
 **Do this if you are asked to generate artistic guides, refine concepts, or refine mediums, generate music prompts, or refine music prompts.**
 - For each concept (after you've completed the concept & medium phases), prompt by:

--- a/lofn/ui.py
+++ b/lofn/ui.py
@@ -9,7 +9,9 @@ from image_generation import (
     render_image_controls,
     get_model_params,
     generate_dalle_images,
+    save_music_metadata,
 )
+from datetime import datetime
 from config import Config
 from helpers import *
 from llm_integration import *
@@ -603,7 +605,7 @@ class LofnApp:
                     )
                     st.session_state['custom_panel'] = panel_text
                 display_temporary_results("Panel Prompt", panel_text, expanded=False)
-            meta_prompt, genres_list = generate_meta_prompt(
+            meta_prompt, frames_list, genres_list = generate_meta_prompt(
                 st.session_state.get('input', ''),
                 max_retries=self.max_retries,
                 temperature=self.temperature,
@@ -617,6 +619,7 @@ class LofnApp:
                 template.replace('{Meta-Prompt}', meta_prompt['meta_prompt'])
                 .replace('{Panel-prompt}', panel_text)
                 .replace('{genres_list}', genres_list)
+                .replace('{frames_list}', frames_list)
             )
             display_temporary_results("Meta Prompt", meta_prompt['meta_prompt'], expanded=False)
             with st.spinner("Generating music prompts..."):
@@ -631,6 +634,17 @@ class LofnApp:
             st.session_state['music_prompt'] = music_prompt
             st.session_state['lyrics_prompt'] = lyrics_prompt
             st.session_state['music_title'] = music_title
+
+            metadata = {
+                'timestamp': datetime.now(),
+                'title': music_title,
+                'music_prompt': music_prompt,
+                'lyrics_prompt': lyrics_prompt,
+                'input_text': st.session_state.get('input', ''),
+                'competition': True,
+                'model': self.model,
+            }
+            save_music_metadata(metadata)
             st.success("Music prompts generated successfully!")
             self.display_music_prompts()
         except Exception as e:
@@ -863,6 +877,16 @@ class LofnApp:
             st.session_state['music_prompt'] = music_prompt
             st.session_state['lyrics_prompt'] = lyrics_prompt
             st.session_state['music_title'] = music_title
+            metadata = {
+                'timestamp': datetime.now(),
+                'title': music_title,
+                'music_prompt': music_prompt,
+                'lyrics_prompt': lyrics_prompt,
+                'input_text': st.session_state['input'],
+                'competition': False,
+                'model': self.model,
+            }
+            save_music_metadata(metadata)
             st.success("Music prompts generated successfully!")
             self.display_music_prompts()
         except Exception as e:

--- a/tests/test_music_genres.py
+++ b/tests/test_music_genres.py
@@ -1,0 +1,31 @@
+import sys
+import os
+import types
+
+# Stub dependencies
+streamlit_stub = types.SimpleNamespace(session_state={})
+sys.modules['streamlit'] = streamlit_stub
+sys.modules['requests'] = types.SimpleNamespace(post=lambda *a, **k: None)
+sys.modules['json_repair'] = types.SimpleNamespace(repair_json=lambda s: s)
+
+plotly_module = types.ModuleType("plotly")
+graph_objects_module = types.ModuleType("plotly.graph_objects")
+plotly_module.graph_objects = graph_objects_module
+sys.modules['plotly'] = plotly_module
+sys.modules['plotly.graph_objects'] = graph_objects_module
+
+# Make repo root importable
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, REPO_ROOT)
+
+import importlib
+config_module = importlib.import_module('lofn.config')
+sys.modules['config'] = config_module
+from lofn.helpers import sample_music_genres
+
+
+def test_sample_music_genres_returns_lines():
+    data = sample_music_genres(min_count=5, max_count=5)
+    lines = data.split('\n')
+    assert len(lines) == 5
+    assert all(line for line in lines)


### PR DESCRIPTION
## Summary
- add saved music metadata
- include frames and genres lists for music
- use relative path for genres dataset
- add basic genres test
- document new `/music` volume

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68562f837fc88329861c39957c9f737e