### PR TITLE
Add video metadata saving and cache competition steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ To set up Lofn, follow these steps:
 5. **Run the Docker container**:
 
    ```bash
-   docker run -p 8501:8501 -v $(pwd)/images:/images -v $(pwd)/metadata:/metadata -v $(pwd)/music:/music lofn
+   docker run -p 8501:8501 -v $(pwd)/images:/images -v $(pwd)/metadata:/metadata -v $(pwd)/music:/music -v $(pwd)/videos:/videos lofn
    ```
 
 6. **Access the Lofn UI**:
@@ -139,12 +139,15 @@ Alternatively, you can use the provided `Dockerfile` and `entrypoint.sh` scripts
 
    Lofn can generate images directly if you have configured the image generation settings accordingly. The images will be displayed in the UI and saved to your specified output directory.
 
+   Video prompts generated in this mode will also be saved to the `/videos` directory for later use.
+
    ![Lofn UI 5](examples/lofn_ui_5.png)
 
 7. **Review Generated Content**.
 
    - View the generated images, titles, Instagram captions, and SEO keywords.
    - Optionally, generate video prompts compatible with Runway Gen-3 Alpha.
+   - Video prompt metadata saved alongside any generated clips in the `/videos` directory.
 
    ![Lofn UI 6](examples/lofn_ui_6.png)
 

--- a/lofn/image_generation.py
+++ b/lofn/image_generation.py
@@ -961,3 +961,21 @@ def save_music_metadata(metadata):
         json.dump(metadata, f, indent=2, default=json_serializable)
 
     st.write(f"Music metadata saved as {metadata_filename}")
+
+
+def save_video_metadata(metadata):
+    """Persist video prompt metadata to disk."""
+    os.makedirs('/videos', exist_ok=True)
+    metadata_filename = (
+        f"/videos/{metadata['timestamp']}_{metadata['concept'][0:10]}_{metadata['medium'][0:10]}.json"
+    )
+
+    def json_serializable(obj):
+        if isinstance(obj, datetime):
+            return obj.isoformat()
+        raise TypeError(f'Type {type(obj)} not serializable')
+
+    with open(metadata_filename, 'w') as f:
+        json.dump(metadata, f, indent=2, default=json_serializable)
+
+    st.write(f"Video metadata saved as {metadata_filename}")

--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -1487,6 +1487,7 @@ def generate_music_prompts(
         logger.exception("Error generating music prompts: %s", e)
         raise e
 
+@st.cache_data(persist=True)
 def generate_meta_prompt(
     input_text,
     max_retries,
@@ -1533,6 +1534,7 @@ def generate_meta_prompt(
         logger.exception("Error generating meta prompt: %s", e)
         raise e
 
+@st.cache_data(persist=True)
 def generate_panel_prompt(input_text, max_retries, temperature, model="gpt-3.5-turbo-16k", debug=False, reasoning_level="medium"):
     """Generate an artistic panel description via the LLM."""
     try:
@@ -1560,6 +1562,7 @@ def generate_panel_prompt(input_text, max_retries, temperature, model="gpt-3.5-t
         logger.exception("Error generating panel prompt: %s", e)
         raise e
 
+@st.cache_data(persist=True)
 def select_best_pairs(input_text, pairs, num_best_pairs, max_retries, temperature, model="gpt-3.5-turbo-16k", debug=False, reasoning_level="medium"):
     """Use the panel to vote on the best concept-medium pairs."""
     try:

--- a/lofn/ui.py
+++ b/lofn/ui.py
@@ -10,6 +10,7 @@ from image_generation import (
     get_model_params,
     generate_dalle_images,
     save_music_metadata,
+    save_video_metadata,
 )
 from datetime import datetime
 from config import Config
@@ -808,6 +809,16 @@ class LofnApp:
                 )
             st.session_state['video_prompts_df'] = prompts_df
             st.success(f"Video prompts generated for '{pair['concept']}'")
+            metadata = {
+                'timestamp': datetime.now(),
+                'concept': pair['concept'],
+                'medium': pair['medium'],
+                'prompts': prompts_df.to_dict(orient='list'),
+                'input_text': st.session_state.get('input', ''),
+                'competition': st.session_state.get('competition_mode', False),
+                'model': self.model,
+            }
+            save_video_metadata(metadata)
             self.display_video_prompts(prompts_df, pair)
         except Exception as e:
             st.error(f"An error occurred while generating video prompts for '{pair['concept']}'.")


### PR DESCRIPTION
## Summary
- cache panel/competition helpers for better performance
- save video prompt metadata alongside generated clips
- record video metadata when video prompts are created
- document new `/videos` directory in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68646a8d0b3c832997678a3ee8d45c94