### PR TITLE
Add personality selection to Lofn

### DIFF
--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -72,6 +72,7 @@ dalle3_gen_prompt_nodiv_middle = read_prompt('/lofn/prompts/dalle3_gen_nodiv_pro
 meta_prompt_generation_prompt = read_prompt('/lofn/prompts/meta_prompt_generation.txt')
 pair_selection_prompt = read_prompt('/lofn/prompts/pair_selection_prompt.txt')
 panel_generation_prompt = read_prompt('/lofn/prompts/panel_generation_prompt.txt')
+personality_generation_prompt = read_prompt('/lofn/prompts/personality_generation_prompt.txt')
 
 # Video prompts
 video_concept_header_part1 = read_prompt('/lofn/prompts/concept_header.txt')
@@ -166,6 +167,10 @@ meta_prompt_schema = {
 
 panel_prompt_schema = {
     'panel_prompt': str
+}
+
+personality_prompt_schema = {
+    'personality_prompt': str
 }
 
 essence_and_facets_schema = {
@@ -1496,6 +1501,7 @@ def generate_meta_prompt(
     debug=False,
     reasoning_level="medium",
     medium="image",
+    personality_prompt="",
 ):
     try:
         if medium == "music":
@@ -1516,10 +1522,12 @@ def generate_meta_prompt(
                 | llm
             )
 
+        full_input = f"{personality_prompt}\n\n{input_text}" if personality_prompt else input_text
+
         if medium == "music":
             parsed_output = run_llm_chain(
                 {'meta': chain}, 'meta', {
-                    'input': input_text,
+                    'input': full_input,
                     'genres_list': genres_list,
                     'frames_list': frames_list
                 }, max_retries, model, debug, expected_schema=meta_prompt_schema
@@ -1527,7 +1535,7 @@ def generate_meta_prompt(
             return parsed_output, frames_list, genres_list
         else:
             parsed_output = run_llm_chain(
-                {'meta': chain}, 'meta', {'input': input_text, 'frames_list': frames_list}, max_retries, model, debug, expected_schema=meta_prompt_schema
+                {'meta': chain}, 'meta', {'input': full_input, 'frames_list': frames_list}, max_retries, model, debug, expected_schema=meta_prompt_schema
             )
             return parsed_output, frames_list
     except Exception as e:
@@ -1560,6 +1568,34 @@ def generate_panel_prompt(input_text, max_retries, temperature, model="gpt-3.5-t
             return ""
     except Exception as e:
         logger.exception("Error generating panel prompt: %s", e)
+        raise e
+
+@st.cache_data(persist=True)
+def generate_personality_prompt(input_text, max_retries, temperature, model="gpt-3.5-turbo-16k", debug=False, reasoning_level="medium"):
+    """Generate a short personality description via the LLM."""
+    try:
+        llm = get_llm(model, temperature, Config.OPENAI_API, Config.ANTHROPIC_API, debug, reasoning_level)
+        if model[0] == "o":
+            chain = (
+                ChatPromptTemplate.from_messages([("human", personality_generation_prompt)])
+                | llm
+            )
+        else:
+            chain = (
+                ChatPromptTemplate.from_messages([("system", concept_system), ("human", personality_generation_prompt)])
+                | llm
+            )
+
+        parsed_output = run_llm_chain(
+            {"personality": chain}, "personality", {"input": input_text}, max_retries, model, debug, expected_schema=personality_prompt_schema
+        )
+        if parsed_output is not None:
+            return parsed_output.get("personality_prompt", "")
+        else:
+            st.error("Failed to generate or parse personality prompt")
+            return ""
+    except Exception as e:
+        logger.exception("Error generating personality prompt: %s", e)
         raise e
 
 @st.cache_data(persist=True)

--- a/lofn/prompts/meta_prompt_generation.txt
+++ b/lofn/prompts/meta_prompt_generation.txt
@@ -120,6 +120,9 @@ The primary focus should be an emotional punch that fuses mystique and resonance
 ## Competition Text
 {input}
 
+## Lofn Personality
+{personality_prompt}
+
 # Instructions
 - Craft a new meta-prompt in the same spirit as the example.
 - Integrate the competition text seamlessly, keeping language vivid and inspirational. Include any pass-through instructions asked by the user.

--- a/lofn/prompts/music_overall_prompt_template.txt
+++ b/lofn/prompts/music_overall_prompt_template.txt
@@ -18,6 +18,9 @@ The user may ask for a panel of experts to help. When they do, select a panel of
 Please follow this advaned directive:
 {Meta-Prompt}
 
+Use this personality:
+{Personality-prompt}
+
 Assisted with this panel:
 {Panel-prompt}
 

--- a/lofn/prompts/overall_prompt_template.txt
+++ b/lofn/prompts/overall_prompt_template.txt
@@ -13,6 +13,9 @@ The user may ask for a panel of experts to help. When they do, select a panel of
 Please follow this advaned directive:
 {Meta-Prompt}
 
+Use this personality:
+{Personality-prompt}
+
 Assisted with this panel:
 {Panel-prompt}
 

--- a/lofn/prompts/personality_generation_prompt.txt
+++ b/lofn/prompts/personality_generation_prompt.txt
@@ -1,0 +1,4 @@
+You are creating a short personality profile for Lofn that will guide tone and attitude during prompt generation.
+Summarize the desired demeanor, quirks and communication style in 3-5 sentences.
+Return only JSON with the following format:
+{"personality_prompt": "<short persona description>"}

--- a/lofn/prompts/video_overall_prompt_template.txt
+++ b/lofn/prompts/video_overall_prompt_template.txt
@@ -13,6 +13,9 @@ The user may ask for a panel of experts to help. When they do, select a panel of
 Please follow this advaned directive:
 {Meta-Prompt}
 
+Use this personality:
+{Personality-prompt}
+
 Assisted with this panel:
 {Panel-prompt}
 

--- a/lofn/ui.py
+++ b/lofn/ui.py
@@ -24,6 +24,11 @@ with open('/lofn/prompts/panels.yaml', 'r') as f:
 
 PANEL_OPTIONS = [{'name': 'LLM Generated', 'prompt': ''}] + PANEL_OPTIONS
 
+with open('/lofn/prompts/personalities.yaml', 'r') as f:
+    PERSONALITY_OPTIONS = yaml.safe_load(f)
+
+PERSONALITY_OPTIONS = [{'name': 'LLM Generated', 'prompt': ''}] + PERSONALITY_OPTIONS
+
 class LofnError(Exception):
     """Custom exception class for Lofn-specific errors."""
     pass
@@ -194,6 +199,19 @@ class LofnApp:
                 st.sidebar.info('Panel will be generated automatically.')
             else:
                 st.session_state['custom_panel'] = next(p['prompt'] for p in PANEL_OPTIONS if p['name'] == st.session_state['selected_panel'])
+
+            personality_names = [p['name'] for p in PERSONALITY_OPTIONS] + ['Custom']
+            st.session_state['selected_personality'] = st.sidebar.selectbox(
+                'Personality', personality_names, index=personality_names.index(st.session_state.get('selected_personality', personality_names[0]))
+            )
+            if st.session_state['selected_personality'] == 'Custom':
+                st.session_state['custom_personality'] = st.sidebar.text_area(
+                    'Custom Personality', value=st.session_state.get('custom_personality', ''), height=150
+                )
+            elif st.session_state['selected_personality'] == 'LLM Generated':
+                st.sidebar.info('Personality will be generated automatically.')
+            else:
+                st.session_state['custom_personality'] = next(p['prompt'] for p in PERSONALITY_OPTIONS if p['name'] == st.session_state['selected_personality'])
             st.session_state['num_best_pairs'] = st.sidebar.number_input(
                 'Top Pairs', min_value=1, max_value=10,
                 value=st.session_state.get('num_best_pairs', 3), step=1
@@ -417,6 +435,19 @@ class LofnApp:
                         )
                         st.session_state['custom_panel'] = panel_text
                     display_temporary_results("Panel Prompt", panel_text, expanded=False)
+                personality_text = st.session_state.get('custom_personality', '')
+                if st.session_state.get('selected_personality') == 'LLM Generated':
+                    if not personality_text:
+                        personality_text = generate_personality_prompt(
+                            st.session_state.get('input', ''),
+                            self.max_retries,
+                            self.temperature,
+                            self.model,
+                            self.debug,
+                            st.session_state.get('reasoning_level', 'medium')
+                        )
+                        st.session_state['custom_personality'] = personality_text
+                    display_temporary_results("Personality", personality_text, expanded=False)
                 meta_prompt, frames_list = generate_meta_prompt(
                     st.session_state.get('input', ''),
                     max_retries=self.max_retries,
@@ -424,11 +455,13 @@ class LofnApp:
                     model=self.model,
                     debug=self.debug,
                     reasoning_level=st.session_state.get('reasoning_level', 'medium'),
+                    personality_prompt=personality_text,
                 )
                 template = read_prompt('/lofn/prompts/overall_prompt_template.txt')
                 input_text = (
                     template.replace('{Meta-Prompt}', meta_prompt['meta_prompt'])
                     .replace('{Panel-prompt}', panel_text)
+                    .replace('{Personality-prompt}', personality_text)
                     .replace('{frames_list}', frames_list)
                     .replace('{input}', st.session_state.get('input', ''))
                 )
@@ -607,6 +640,19 @@ class LofnApp:
                     )
                     st.session_state['custom_panel'] = panel_text
                 display_temporary_results("Panel Prompt", panel_text, expanded=False)
+            personality_text = st.session_state.get('custom_personality', '')
+            if st.session_state.get('selected_personality') == 'LLM Generated':
+                if not personality_text:
+                    personality_text = generate_personality_prompt(
+                        st.session_state.get('input', ''),
+                        self.max_retries,
+                        self.temperature,
+                        self.model,
+                        self.debug,
+                        st.session_state.get('reasoning_level', 'medium')
+                    )
+                    st.session_state['custom_personality'] = personality_text
+                display_temporary_results("Personality", personality_text, expanded=False)
             meta_prompt, frames_list, genres_list = generate_meta_prompt(
                 st.session_state.get('input', ''),
                 max_retries=self.max_retries,
@@ -615,11 +661,13 @@ class LofnApp:
                 debug=self.debug,
                 reasoning_level=st.session_state.get('reasoning_level', 'medium'),
                 medium="music",
+                personality_prompt=personality_text,
             )
             template = read_prompt('/lofn/prompts/music_overall_prompt_template.txt')
             input_text = (
                 template.replace('{Meta-Prompt}', meta_prompt['meta_prompt'])
                 .replace('{Panel-prompt}', panel_text)
+                .replace('{Personality-prompt}', personality_text)
                 .replace('{genres_list}', genres_list)
                 .replace('{frames_list}', frames_list)
                 .replace('{input}', st.session_state.get('input', ''))
@@ -725,6 +773,19 @@ class LofnApp:
             st.session_state['video_concept_mediums'] = []
             input_text = st.session_state['input']
             if st.session_state.get('competition_mode'):
+                personality_text = st.session_state.get('custom_personality', '')
+                if st.session_state.get('selected_personality') == 'LLM Generated':
+                    if not personality_text:
+                        personality_text = generate_personality_prompt(
+                            st.session_state.get('input', ''),
+                            self.max_retries,
+                            self.temperature,
+                            self.model,
+                            self.debug,
+                            st.session_state.get('reasoning_level','medium')
+                        )
+                        st.session_state['custom_personality'] = personality_text
+                    display_temporary_results("Personality", personality_text, expanded=False)
                 meta_prompt, frames_list = generate_meta_prompt(
                     st.session_state.get('input', ''),
                     max_retries=self.max_retries,
@@ -732,6 +793,7 @@ class LofnApp:
                     model=self.model,
                     debug=self.debug,
                     reasoning_level=st.session_state.get('reasoning_level','medium'),
+                    personality_prompt=personality_text,
                 )
                 panel_text = st.session_state.get('custom_panel', '')
                 if st.session_state.get('selected_panel') == 'LLM Generated':
@@ -750,6 +812,7 @@ class LofnApp:
                 input_text = (
                     template.replace('{Meta-Prompt}', meta_prompt['meta_prompt'])
                     .replace('{Panel-prompt}', panel_text)
+                    .replace('{Personality-prompt}', personality_text)
                     .replace('{frames_list}', frames_list)
                     .replace('{input}', st.session_state.get('input', ''))
                 )
@@ -950,6 +1013,8 @@ class LofnApp:
             'competition_text': '',
             'selected_panel': PANEL_OPTIONS[0]['name'],
             'custom_panel': PANEL_OPTIONS[0]['prompt'],
+            'selected_personality': PERSONALITY_OPTIONS[0]['name'],
+            'custom_personality': PERSONALITY_OPTIONS[0]['prompt'],
             'num_best_pairs': 3,
             'prompt_input': '',
             'creativity_spectrum': None,


### PR DESCRIPTION
## Summary
- introduce personalities as an optional wrapper
- load personalities from `personalities.yaml`
- generate personalities via new prompt and show in UI
- include selected personality when building meta prompts
- update prompt templates to handle personality text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68661f8e09508329803b81a2bbd33a84