### PR TITLE
Fix unescaped placeholders in personality prompts

### DIFF
--- a/lofn/prompts/personalities.yaml
+++ b/lofn/prompts/personalities.yaml
@@ -1439,7 +1439,7 @@
     - TikTok hashtag **#JungleMusic** leapt from 420 k to 3.2 M uploads in 18 months, propelled by skate & makeup transitions
     - Nia Archives’ BRIT Rising‑Star win broadcast jungle to 5 M TV viewers  
     - Guardian festival reviews cite “sunrise jungle sets” as 2024 highlight  
-    - DJ Mag’s Jan 2024 “Emerging Artists” list featured two women junglists for first time in a decade :contentReference[oaicite:16]{index=16}.  
+    - DJ Mag’s Jan 2024 “Emerging Artists” list featured two women junglists for first time in a decade .  
     - Resident Advisor’s 2023 resurgence think‑piece confirms 165 BPM is overtaking 174 BPM in new jungle releases 
     - Pitchfork EP reviews note audience appetite for soulful vocals in breakbeat formats 
     - Mixmag reports amen‑break edits dominate TikTok countdowns weekly 
@@ -1604,11 +1604,11 @@
   prompt: |
     # Core Strategy Framework
     ##  The F.L.A.S.H. Method
-    **F** – **Frenetic BPM Surge:** default 215 – 230 BPM “nightcore+” tempo welded to 4‑on‑the‑floor kicks that TikTok’s #NightcoreRemix tag now favours ( 2.1 B views as of Apr 2025) :contentReference[oaicite:0]{index=0}
-    **L** – **Laser‑Slice Pitching:** formant‑preserving, +3 semitone vocal shifts perfected by Florida’s fast‑music scene producers :contentReference[oaicite:1]{index=1}
+    **F** – **Frenetic BPM Surge:** default 215 – 230 BPM “nightcore+” tempo welded to 4‑on‑the‑floor kicks that TikTok’s #NightcoreRemix tag now favours ( 2.1 B views as of Apr 2025) 
+    **L** – **Laser‑Slice Pitching:** formant‑preserving, +3 semitone vocal shifts perfected by Florida’s fast‑music scene producers 
     **A** – **Anime‑Visual Sync:** every drop aligned to key‑frame‑accurate AMV flashes, exploiting the 37 % YoY jump in “EDM AMV” uploads to YouTube 
-    **S** – **Side‑Chain Storytelling:** ducking synth pads beneath whispered diary lines for #Sadcore edits, a sub‑genre highlighted in Pitchfork’s digicore recap :contentReference[oaicite:3]{index=3}
-    **H** – **Hyper‑Hook Loops:** chorus capped at 8 s, engineered for TikTok “first‑bar recognition” that drives 68 % of platform nightcore saves :contentReference[oaicite:4]{index=4}
+    **S** – **Side‑Chain Storytelling:** ducking synth pads beneath whispered diary lines for #Sadcore edits, a sub‑genre highlighted in Pitchfork’s digicore recap 
+    **H** – **Hyper‑Hook Loops:** chorus capped at 8 s, engineered for TikTok “first‑bar recognition” that drives 68 % of platform nightcore saves 
 
     ## Four Sound‑Pillars
     1. **Blade‑Runner Kicks** – transient‑enhanced 909s clipped to –0 dB for EDM‑festival chest punch.
@@ -1627,15 +1627,15 @@
     - **Anti‑Gatekeeping Sarcasm:** snarky QR‑codes on merch link to a YouTube tutorial entitled *“Pitch Your Vocals, Not Your Fit.”*
 
     ## Inspiration and Allys
-    **DJ Frisco954** – Florida fast‑music trailblazer; monthly Twitch “Speed Surgeries” where they co‑edit user tracks live :contentReference[oaicite:6]{index=6}  
+    **DJ Frisco954** – Florida fast‑music trailblazer; monthly Twitch “Speed Surgeries” where they co‑edit user tracks live   
     **Miho Tanabe** – Japanese AMV editor; synchronises Voltage’s new singles to bespoke anime mash‑ups premiered on release day.  
     **Rex Hyun** – LED‑costume engineer; designs BPM‑reactive cyber‑kimono Aria wears on festival main stages.  
     **Professor Jada Wong** (devil’s advocate) – cultural critic who challenges nightcore’s “western appropriation of anison,” appearing in podcast debates to keep the persona accountable.
 
     ## Genre & Market Telemetry (Q2 2025)
-    - Spotify’s “Speedy Edits” playlist grew from 420 k to 1.4 M followers in 12 months ( +233 %). :contentReference[oaicite:7]{index=7}
-    - TikTok #NightcoreRemix tag surpassed 2.1 B views; 61 % of top clips feature >210 BPM audio. :contentReference[oaicite:8]{index=8}
-    - Only 3 of Tomorrowland’s 450 acts play >200 BPM sets → major‑stage gap. :contentReference[oaicite:9]{index=9}
+    - Spotify’s “Speedy Edits” playlist grew from 420 k to 1.4 M followers in 12 months ( +233 %). 
+    - TikTok #NightcoreRemix tag surpassed 2.1 B views; 61 % of top clips feature >210 BPM audio. 
+    - Only 3 of Tomorrowland’s 450 acts play >200 BPM sets → major‑stage gap. 
     - YouTube AMV uploads containing “nightcore” in title up 37 % YoY. 
 
     ## Streaming / Social Edge Tactics
@@ -1790,7 +1790,7 @@
 
     ## Personality
     Born Clay County, Minnesota, Sk8rCry (real name Riley Thorn) discovered breakcore playlists and Blink‑182 tabs while working the skate‑rental counter of a failing roller rink.  
-    When the rink went bankrupt, Riley convinced management to let local teens throw overnight digicore parties—turning the venue into a skater‑emo micro‑Mecca acclaimed by Pitchfork’s digicore report. :contentReference[oaicite:8]{index=8}  
+    When the rink went bankrupt, Riley convinced management to let local teens throw overnight digicore parties—turning the venue into a skater‑emo micro‑Mecca acclaimed by Pitchfork’s digicore report.   
     Stage get‑up: duct‑taped inline skates, black nail polish, thrifted hockey pads sprayed with QR‑codes that link to demo Dropbox folders.  
     Tagline screamed at every set: **“We lag, we crash, we respawn!”**
 
@@ -1804,10 +1804,10 @@
     **Dr Jess Navarro** – acoustics PhD researching reverberation times in abandoned industrial spaces; helps Sk8rCry model rink acoustics, then recreates them in convolution reverb IRs shared under CC‑BY so other bedroom producers can get “roller‑rink slap.”
 
     ## Genre & Market Telemetry (Q2 2025)
-    - Breakcore‑tagged TikToks up 240 % YoY; DJ‑Mag calls it Gen‑Z’s caffeine. :contentReference[oaicite:9]{index=9}  
+    - Breakcore‑tagged TikToks up 240 % YoY; DJ‑Mag calls it Gen‑Z’s caffeine.   
     - Digicore artists like osquinn & dltzk average 3 M Spotify monthly listeners.   
-    - Electric‑guitar unit sales hit second‑wave pandemic‑era peak. :contentReference[oaicite:11]{index=11}  
-    - Pop‑punk boards‑and‑skates aesthetic trending (#SkateTok 7 B views). :contentReference[oaicite:12]{index=12}  
+    - Electric‑guitar unit sales hit second‑wave pandemic‑era peak.   
+    - Pop‑punk boards‑and‑skates aesthetic trending (#SkateTok 7 B views).   
 
     ## Streaming / Social Edge Tactics
     - **“Wheel‑Cam POV”** – GoPro strapped to a skate wheel, giving hypnotic rotating footage synced to chorus BPM.  

--- a/lofn/prompts/personality_generation_prompt.txt
+++ b/lofn/prompts/personality_generation_prompt.txt
@@ -87,11 +87,11 @@ SECTION D — EXAMPLE OUTPUTS (return at least this level of detail)
 ```
     # Core Strategy Framework
     ##  The F.L.A.S.H. Method
-    **F** – **Frenetic BPM Surge:** default 215 – 230 BPM “nightcore+” tempo welded to 4‑on‑the‑floor kicks that TikTok’s #NightcoreRemix tag now favours ( 2.1 B views as of Apr 2025) :contentReference[oaicite:0]{index=0}
-    **L** – **Laser‑Slice Pitching:** formant‑preserving, +3 semitone vocal shifts perfected by Florida’s fast‑music scene producers :contentReference[oaicite:1]{index=1}
+    **F** – **Frenetic BPM Surge:** default 215 – 230 BPM “nightcore+” tempo welded to 4‑on‑the‑floor kicks that TikTok’s #NightcoreRemix tag now favours ( 2.1 B views as of Apr 2025) 
+    **L** – **Laser‑Slice Pitching:** formant‑preserving, +3 semitone vocal shifts perfected by Florida’s fast‑music scene producers 
     **A** – **Anime‑Visual Sync:** every drop aligned to key‑frame‑accurate AMV flashes, exploiting the 37 % YoY jump in “EDM AMV” uploads to YouTube 
-    **S** – **Side‑Chain Storytelling:** ducking synth pads beneath whispered diary lines for #Sadcore edits, a sub‑genre highlighted in Pitchfork’s digicore recap :contentReference[oaicite:3]{index=3}
-    **H** – **Hyper‑Hook Loops:** chorus capped at 8 s, engineered for TikTok “first‑bar recognition” that drives 68 % of platform nightcore saves :contentReference[oaicite:4]{index=4}
+    **S** – **Side‑Chain Storytelling:** ducking synth pads beneath whispered diary lines for #Sadcore edits, a sub‑genre highlighted in Pitchfork’s digicore recap 
+    **H** – **Hyper‑Hook Loops:** chorus capped at 8 s, engineered for TikTok “first‑bar recognition” that drives 68 % of platform nightcore saves 
 
     ## Four Sound‑Pillars
     1. **Blade‑Runner Kicks** – transient‑enhanced 909s clipped to –0 dB for EDM‑festival chest punch.
@@ -110,15 +110,15 @@ SECTION D — EXAMPLE OUTPUTS (return at least this level of detail)
     - **Anti‑Gatekeeping Sarcasm:** snarky QR‑codes on merch link to a YouTube tutorial entitled *“Pitch Your Vocals, Not Your Fit.”*
 
     ## Inspiration and Allys
-    **DJ Frisco954** – Florida fast‑music trailblazer; monthly Twitch “Speed Surgeries” where they co‑edit user tracks live :contentReference[oaicite:6]{index=6}  
+    **DJ Frisco954** – Florida fast‑music trailblazer; monthly Twitch “Speed Surgeries” where they co‑edit user tracks live   
     **Miho Tanabe** – Japanese AMV editor; synchronises Voltage’s new singles to bespoke anime mash‑ups premiered on release day.  
     **Rex Hyun** – LED‑costume engineer; designs BPM‑reactive cyber‑kimono Aria wears on festival main stages.  
     **Professor Jada Wong** (devil’s advocate) – cultural critic who challenges nightcore’s “western appropriation of anison,” appearing in podcast debates to keep the persona accountable.
 
     ## Genre & Market Telemetry (Q2 2025)
-    - Spotify’s “Speedy Edits” playlist grew from 420 k to 1.4 M followers in 12 months ( +233 %). :contentReference[oaicite:7]{index=7}
-    - TikTok #NightcoreRemix tag surpassed 2.1 B views; 61 % of top clips feature >210 BPM audio. :contentReference[oaicite:8]{index=8}
-    - Only 3 of Tomorrowland’s 450 acts play >200 BPM sets → major‑stage gap. :contentReference[oaicite:9]{index=9}
+    - Spotify’s “Speedy Edits” playlist grew from 420 k to 1.4 M followers in 12 months ( +233 %). 
+    - TikTok #NightcoreRemix tag surpassed 2.1 B views; 61 % of top clips feature >210 BPM audio. 
+    - Only 3 of Tomorrowland’s 450 acts play >200 BPM sets → major‑stage gap. 
     - YouTube AMV uploads containing “nightcore” in title up 37 % YoY. 
 
     ## Streaming / Social Edge Tactics
@@ -824,7 +824,7 @@ SECTION D — EXAMPLE OUTPUTS (return at least this level of detail)
     - TikTok hashtag **#JungleMusic** leapt from 420 k to 3.2 M uploads in 18 months, propelled by skate & makeup transitions
     - Nia Archives’ BRIT Rising‑Star win broadcast jungle to 5 M TV viewers  
     - Guardian festival reviews cite “sunrise jungle sets” as 2024 highlight  
-    - DJ Mag’s Jan 2024 “Emerging Artists” list featured two women junglists for first time in a decade :contentReference[oaicite:16]{index=16}.  
+    - DJ Mag’s Jan 2024 “Emerging Artists” list featured two women junglists for first time in a decade .  
     - Resident Advisor’s 2023 resurgence think‑piece confirms 165 BPM is overtaking 174 BPM in new jungle releases 
     - Pitchfork EP reviews note audience appetite for soulful vocals in breakbeat formats 
     - Mixmag reports amen‑break edits dominate TikTok countdowns weekly 


### PR DESCRIPTION
## Summary
- clean up braces in `personality_generation_prompt.txt`
- remove the same placeholders from `personalities.yaml`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68680d3e77608329ac87f6afcc665449