### PR TITLE
Add session settings to saved metadata

### DIFF
--- a/lofn/helpers.py
+++ b/lofn/helpers.py
@@ -482,6 +482,19 @@ def truncate_prompt(prompt: Union[str, List[dict]], max_tokens: int = 3000) -> U
                 break
         return truncated_prompt
 
+def get_input_settings() -> dict:
+    """Return a JSON-serializable copy of ``st.session_state``."""
+    allowed_types = (int, float, str, bool, list, dict, type(None))
+    settings = {}
+    for key, value in st.session_state.items():
+        if isinstance(value, allowed_types):
+            try:
+                json.dumps(value)
+            except TypeError:
+                continue
+            settings[key] = value
+    return settings
+
 def send_to_discord(content, content_type='prompts', premessage=''):
     try:
         if st.session_state['send_to_discord']:

--- a/lofn/image_generation.py
+++ b/lofn/image_generation.py
@@ -941,6 +941,17 @@ def save_metadata(metadata):
             return obj.isoformat()
         raise TypeError(f"Type {type(obj)} not serializable")
 
+    metadata['input_settings'] = get_input_settings()
+    panel = st.session_state.get('custom_panel')
+    if panel:
+        metadata['panel_prompt'] = panel
+    personality = st.session_state.get('custom_personality')
+    if personality:
+        metadata['personality_prompt'] = personality
+    meta_prompt = st.session_state.get('meta_prompt')
+    if meta_prompt:
+        metadata['meta_prompt'] = meta_prompt
+
     # Save the metadata as a JSON file
     with open(metadata_filename, 'w') as f:
         json.dump(metadata, f, indent=2, default=json_serializable)
@@ -956,6 +967,17 @@ def save_music_metadata(metadata):
         if isinstance(obj, datetime):
             return obj.isoformat()
         raise TypeError(f'Type {type(obj)} not serializable')
+
+    metadata['input_settings'] = get_input_settings()
+    panel = st.session_state.get('custom_panel')
+    if panel:
+        metadata['panel_prompt'] = panel
+    personality = st.session_state.get('custom_personality')
+    if personality:
+        metadata['personality_prompt'] = personality
+    meta_prompt = st.session_state.get('meta_prompt')
+    if meta_prompt:
+        metadata['meta_prompt'] = meta_prompt
 
     with open(metadata_filename, 'w') as f:
         json.dump(metadata, f, indent=2, default=json_serializable)
@@ -974,6 +996,17 @@ def save_video_metadata(metadata):
         if isinstance(obj, datetime):
             return obj.isoformat()
         raise TypeError(f'Type {type(obj)} not serializable')
+
+    metadata['input_settings'] = get_input_settings()
+    panel = st.session_state.get('custom_panel')
+    if panel:
+        metadata['panel_prompt'] = panel
+    personality = st.session_state.get('custom_personality')
+    if personality:
+        metadata['personality_prompt'] = personality
+    meta_prompt = st.session_state.get('meta_prompt')
+    if meta_prompt:
+        metadata['meta_prompt'] = meta_prompt
 
     with open(metadata_filename, 'w') as f:
         json.dump(metadata, f, indent=2, default=json_serializable)

--- a/lofn/ui.py
+++ b/lofn/ui.py
@@ -457,6 +457,7 @@ class LofnApp:
                     reasoning_level=st.session_state.get('reasoning_level', 'medium'),
                     personality_prompt=personality_text,
                 )
+                st.session_state['meta_prompt'] = meta_prompt['meta_prompt']
                 template = read_prompt('/lofn/prompts/overall_prompt_template.txt')
                 input_text = (
                     template.replace('{Meta-Prompt}', meta_prompt['meta_prompt'])
@@ -663,6 +664,7 @@ class LofnApp:
                 medium="music",
                 personality_prompt=personality_text,
             )
+            st.session_state['meta_prompt'] = meta_prompt['meta_prompt']
             template = read_prompt('/lofn/prompts/music_overall_prompt_template.txt')
             input_text = (
                 template.replace('{Meta-Prompt}', meta_prompt['meta_prompt'])
@@ -795,6 +797,7 @@ class LofnApp:
                     reasoning_level=st.session_state.get('reasoning_level','medium'),
                     personality_prompt=personality_text,
                 )
+                st.session_state['meta_prompt'] = meta_prompt['meta_prompt']
                 panel_text = st.session_state.get('custom_panel', '')
                 if st.session_state.get('selected_panel') == 'LLM Generated':
                     if not panel_text:


### PR DESCRIPTION
## Summary
- add helper to collect serialisable input settings
- store session settings, panel prompt, personality prompt and meta prompt when saving image, music and video metadata
- keep last generated meta prompt in session state for images, music and video

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ca9ec06b883299e3d951af030dc4e