### PR TITLE
Use personality before panel generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ All behavioural constants sit in `lofn/constants.py` (tree widths, critic weight
 
 1. **Choose Mode** (Art, Music, Video)
 2. **Toggle Competition** *(optional)*
-3. **Select / Generate Panel** & set **Personality**
+3. **Generate Personality** → then **Select / Generate Panel**
 4. **Enter Idea** — one sentence is enough
 5. **Generate** → Review concepts → Pick or iterate
 6. **Copy Prompt** *or* let Lofn call the generator API automatically

--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -1560,7 +1560,15 @@ def generate_meta_prompt(
         raise e
 
 @st.cache_data(persist=True)
-def generate_panel_prompt(input_text, max_retries, temperature, model="gpt-3.5-turbo-16k", debug=False, reasoning_level="medium"):
+def generate_panel_prompt(
+    input_text,
+    max_retries,
+    temperature,
+    model="gpt-3.5-turbo-16k",
+    debug=False,
+    reasoning_level="medium",
+    personality_prompt="",
+):
     """Generate an artistic panel description via the LLM."""
     try:
         llm = get_llm(model, temperature, Config.OPENAI_API, Config.ANTHROPIC_API, debug, reasoning_level)
@@ -1575,8 +1583,16 @@ def generate_panel_prompt(input_text, max_retries, temperature, model="gpt-3.5-t
                 | llm
             )
 
+        full_input = f"{personality_prompt}\n\n{input_text}" if personality_prompt else input_text
+
         parsed_output = run_llm_chain(
-            {"panel": chain}, "panel", {"input": input_text}, max_retries, model, debug, expected_schema=panel_prompt_schema
+            {"panel": chain},
+            "panel",
+            {"input": full_input, "personality_prompt": personality_prompt},
+            max_retries,
+            model,
+            debug,
+            expected_schema=panel_prompt_schema,
         )
         if parsed_output is not None:
             return parsed_output.get("panel_prompt", "")

--- a/lofn/prompts/panel_generation_prompt.txt
+++ b/lofn/prompts/panel_generation_prompt.txt
@@ -174,6 +174,9 @@ I want to construct a perfect panel, and seed the perfect flairs to make these 4
 ## Competition Text
 {input}
 
+## Lofn Personality
+{personality_prompt}
+
 # Instructions
 - Craft a new panel-prompt in the same spirit as the examples, but tailored with very obscure, rare, and hidden gem artists who are not well known, but are experts at specific areas, takes, views, and styles in their craft.
 - Complement and enhance the competition concepts with both direct, indirect, and adjacent flairs and panel members.

--- a/lofn/ui.py
+++ b/lofn/ui.py
@@ -422,19 +422,6 @@ class LofnApp:
             st.session_state['progress_step'] = 0
             input_text = st.session_state['input']
             if st.session_state.get('competition_mode'):
-                panel_text = st.session_state.get('custom_panel', '')
-                if st.session_state.get('selected_panel') == 'LLM Generated':
-                    if not panel_text:
-                        panel_text = generate_panel_prompt(
-                            st.session_state.get('input', ''),
-                            self.max_retries,
-                            self.temperature,
-                            self.model,
-                            self.debug,
-                            st.session_state.get('reasoning_level', 'medium')
-                        )
-                        st.session_state['custom_panel'] = panel_text
-                    display_temporary_results("Panel Prompt", panel_text, expanded=False)
                 personality_text = st.session_state.get('custom_personality', '')
                 if st.session_state.get('selected_personality') == 'LLM Generated':
                     if not personality_text:
@@ -448,6 +435,21 @@ class LofnApp:
                         )
                         st.session_state['custom_personality'] = personality_text
                     display_temporary_results("Personality", personality_text, expanded=False)
+
+                panel_text = st.session_state.get('custom_panel', '')
+                if st.session_state.get('selected_panel') == 'LLM Generated':
+                    if not panel_text:
+                        panel_text = generate_panel_prompt(
+                            st.session_state.get('input', ''),
+                            self.max_retries,
+                            self.temperature,
+                            self.model,
+                            self.debug,
+                            st.session_state.get('reasoning_level', 'medium'),
+                            personality_prompt=personality_text,
+                        )
+                        st.session_state['custom_panel'] = panel_text
+                    display_temporary_results("Panel Prompt", panel_text, expanded=False)
                 meta_prompt, frames_list = generate_meta_prompt(
                     st.session_state.get('input', ''),
                     max_retries=self.max_retries,
@@ -628,19 +630,6 @@ class LofnApp:
 
     def run_music_competition(self):
         try:
-            panel_text = st.session_state.get('custom_panel', '')
-            if st.session_state.get('selected_panel') == 'LLM Generated':
-                if not panel_text:
-                    panel_text = generate_panel_prompt(
-                        st.session_state.get('input', ''),
-                        self.max_retries,
-                        self.temperature,
-                        self.model,
-                        self.debug,
-                        st.session_state.get('reasoning_level', 'medium')
-                    )
-                    st.session_state['custom_panel'] = panel_text
-                display_temporary_results("Panel Prompt", panel_text, expanded=False)
             personality_text = st.session_state.get('custom_personality', '')
             if st.session_state.get('selected_personality') == 'LLM Generated':
                 if not personality_text:
@@ -654,6 +643,20 @@ class LofnApp:
                     )
                     st.session_state['custom_personality'] = personality_text
                 display_temporary_results("Personality", personality_text, expanded=False)
+            panel_text = st.session_state.get('custom_panel', '')
+            if st.session_state.get('selected_panel') == 'LLM Generated':
+                if not panel_text:
+                    panel_text = generate_panel_prompt(
+                        st.session_state.get('input', ''),
+                        self.max_retries,
+                        self.temperature,
+                        self.model,
+                        self.debug,
+                        st.session_state.get('reasoning_level', 'medium'),
+                        personality_prompt=personality_text,
+                    )
+                    st.session_state['custom_panel'] = panel_text
+                display_temporary_results("Panel Prompt", panel_text, expanded=False)
             meta_prompt, frames_list, genres_list = generate_meta_prompt(
                 st.session_state.get('input', ''),
                 max_retries=self.max_retries,
@@ -807,7 +810,8 @@ class LofnApp:
                             self.temperature,
                             self.model,
                             self.debug,
-                            st.session_state.get('reasoning_level','medium')
+                            st.session_state.get('reasoning_level','medium'),
+                            personality_prompt=personality_text,
                         )
                         st.session_state['custom_panel'] = panel_text
                     display_temporary_results("Panel Prompt", panel_text, expanded=False)


### PR DESCRIPTION
## Summary
- update README steps to show personality generation before panel
- incorporate personality input when generating panels
- use personality before panel generation across code paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872c0840960832990cd57beb83e1fec