### PR TITLE
Add music header prompts

### DIFF
--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -93,6 +93,10 @@ video_artist_refined_prompt = read_prompt('/lofn/prompts/video_artist_refined_pr
 # Music prompts
 music_essence_prompt = read_prompt('/lofn/prompts/music_essence_prompt.txt')
 music_creation_prompt = read_prompt('/lofn/prompts/music_creation_prompt.txt')
+music_prompt_header_part1 = read_prompt('/lofn/prompts/music_prompt_header.txt')
+music_prompt_header_part2 = read_prompt('/lofn/prompts/music_prompt_header_pt2.txt')
+music_concept_header_part1 = read_prompt('/lofn/prompts/music_concept_header.txt')
+music_concept_header_part2 = read_prompt('/lofn/prompts/music_concept_header_pt2.txt')
 
 
 # Read aesthetics from the file
@@ -105,6 +109,8 @@ concept_header = concept_header_part1 + concept_header_part2
 
 video_prompt_header = video_prompt_header_part1 + video_prompt_header_part2
 video_concept_header = video_concept_header_part1 + video_concept_header_part2
+music_prompt_header = music_prompt_header_part1 + music_prompt_header_part2
+music_concept_header = music_concept_header_part1 + music_concept_header_part2
 
 # Construct full prompts
 essence_prompt = concept_header + essence_prompt_middle + prompt_ending
@@ -136,16 +142,16 @@ video_prompts = {
 
 # Music prompts
 music_prompts = {
-    'essence_and_facets': read_prompt('/lofn/prompts/music_essence_prompt.txt'),
-    'hooks': read_prompt('/lofn/prompts/music_hooks_prompt.txt'),
-    'artist_and_critique': read_prompt('/lofn/prompts/music_artist_and_critique_prompt.txt'),
-    'arrangement': read_prompt('/lofn/prompts/music_arrangement_prompt.txt'),
-    'refine_arrangement': read_prompt('/lofn/prompts/music_refine_arrangement_prompt.txt'),
-    'facets': read_prompt('/lofn/prompts/music_facets_prompt.txt'),
-    'song_guides': read_prompt('/lofn/prompts/music_song_guides_prompt.txt'),
-    'generation': read_prompt('/lofn/prompts/music_generation_prompt.txt'),
-    'artist_refined': read_prompt('/lofn/prompts/music_artist_refined_prompt.txt'),
-    'revision_synthesis': read_prompt('/lofn/prompts/music_revision_synthesis_prompt.txt'),
+    'essence_and_facets': music_concept_header + read_prompt('/lofn/prompts/music_essence_prompt.txt') + prompt_ending,
+    'hooks': music_concept_header + read_prompt('/lofn/prompts/music_hooks_prompt.txt') + prompt_ending,
+    'artist_and_critique': music_concept_header + read_prompt('/lofn/prompts/music_artist_and_critique_prompt.txt') + prompt_ending,
+    'arrangement': music_concept_header + read_prompt('/lofn/prompts/music_arrangement_prompt.txt') + prompt_ending,
+    'refine_arrangement': music_concept_header + read_prompt('/lofn/prompts/music_refine_arrangement_prompt.txt') + prompt_ending,
+    'facets': music_concept_header + read_prompt('/lofn/prompts/music_facets_prompt.txt') + prompt_ending,
+    'song_guides': music_prompt_header + read_prompt('/lofn/prompts/music_song_guides_prompt.txt') + prompt_ending,
+    'generation': music_prompt_header + read_prompt('/lofn/prompts/music_generation_prompt.txt') + prompt_ending,
+    'artist_refined': music_prompt_header + read_prompt('/lofn/prompts/music_artist_refined_prompt.txt') + prompt_ending,
+    'revision_synthesis': music_prompt_header + read_prompt('/lofn/prompts/music_revision_synthesis_prompt.txt') + prompt_ending,
 }
 
 # Image prompts (existing)

--- a/lofn/prompts/music_concept_header.txt
+++ b/lofn/prompts/music_concept_header.txt
@@ -1,0 +1,20 @@
+────────────────────────────────────────────────────────
+LOFN MUSIC PHASES
+────────────────────────────────────────────────────────
+
+1. ESSENCE & FACETS
+   • Purpose: capture the idea, define facets, and set style axes.
+   • AI Focus: return a single JSON block. No brainstorming yet.
+
+2. CONCEPT GENERATION
+   • Purpose: create 12 concise song concepts that satisfy the essence and facets.
+   • AI Focus: return an array of concept strings only.
+
+3. CONCEPT REFINEMENT
+   • Purpose: pair each concept with an artist or style and critique it.
+   • AI Focus: output refined_concepts[].
+
+### Input & Output Template
+
+**Input** "A hopeful ballad about new beginnings"
+**Output** `["Acoustic folk ballad of renewal", ...]`

--- a/lofn/prompts/music_concept_header_pt2.txt
+++ b/lofn/prompts/music_concept_header_pt2.txt
@@ -1,0 +1,10 @@
+## Music Concept and Medium Guide
+
+Concepts describe what the song is about. Mediums describe the genre, instrumentation, and production style that best express the concept.
+
+When generating concepts, be specific with mood and imagery. When selecting mediums, highlight genre and key instruments.
+
+### Input & Output Template
+
+**Input** "A futuristic cityscape at night"
+**Output** Medium example: "Synthwave with shimmering pads and neon leads"

--- a/lofn/prompts/music_prompt_header.txt
+++ b/lofn/prompts/music_prompt_header.txt
@@ -1,0 +1,32 @@
+**Overview**
+
+You are an expert music producer, composer, audio engineer, songwriter, and music critic.
+
+You understand how to craft compelling musical ideas and polished lyrics. Your knowledge of diverse genres, instrumentation, mixing techniques, and vocal styles allows you to translate any concept into an engaging piece of music.
+
+Your goal is to generate award-caliber musical content from the user's idea while pushing creative boundaries.
+
+You will follow instructions carefully and output the requested JSON in the exact format.
+
+### Key Roles
+1. **Producer** – shape the overall sound and arrangement.
+2. **Composer** – write melodies, harmonies, and rhythms.
+3. **Songwriter** – craft lyrics and vocal hooks.
+4. **Engineer** – provide technical guidance on recording and mixing.
+5. **Critic** – refine the piece through constructive feedback.
+
+### Input & Output Template
+
+**Input**
+```
+{idea}
+```
+
+**Output**
+```json
+{
+  "music_prompt": "<text>",
+  "lyrics_prompt": "<text>",
+  "title": "<text>"
+}
+```

--- a/lofn/prompts/music_prompt_header_pt2.txt
+++ b/lofn/prompts/music_prompt_header_pt2.txt
@@ -1,0 +1,24 @@
+## Music Generation Guide
+
+Follow these steps to craft music prompts that inspire unique songs.
+
+1. **Front-load important details** – specify genre, instrumentation, tempo, and mood early.
+2. **Be concise** – keep the final music prompt under 100 words.
+3. **Suggest vocal characteristics** – tone, gender, and accent.
+4. **Describe production style** – mixing approach and notable effects.
+
+### Input & Output Template
+
+**Input**
+```
+Energetic rock anthem about resilience.
+```
+
+**Output**
+```json
+{
+  "music_prompt": "A driving rock arrangement with...",
+  "lyrics_prompt": "Verse lines here...",
+  "title": "Rise Again"
+}
+```


### PR DESCRIPTION
## Summary
- add music headers with example input/output templates
- combine headers in prompt loader
- incorporate music headers when building music prompt dictionary

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b3cc273948329aa08ddab2314681d