### PR TITLE
Add custom personalities file

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,10 @@ A thematic setting that provides a consistent creator persona that lasts between
 
 Leave empty for LLM‑generated defaults or curate for brand consistency.
 
+Custom personas can also be loaded from `lofn/prompts/custom_personalities.yaml`.
+Copy the provided `custom_personalities.yaml.example` file to this location and
+add your own entries to have them appear in the sidebar.
+
 ---
 
 ## 👥 Panels

--- a/lofn/prompts/custom_personalities.yaml.example
+++ b/lofn/prompts/custom_personalities.yaml.example
@@ -1,0 +1,6 @@
+# Copy to custom_personalities.yaml and edit to add your own creator personas.
+# Each entry should contain a 'name' and a multiline 'prompt'.
+
+- name: Example Persona
+  prompt: |
+    Describe your custom creative guidance here.

--- a/lofn/ui.py
+++ b/lofn/ui.py
@@ -27,6 +27,13 @@ PANEL_OPTIONS = [{'name': 'LLM Generated', 'prompt': ''}] + PANEL_OPTIONS
 with open('/lofn/prompts/personalities.yaml', 'r') as f:
     PERSONALITY_OPTIONS = yaml.safe_load(f)
 
+# Merge in user-defined personalities if the optional file exists
+custom_personality_path = '/lofn/prompts/custom_personalities.yaml'
+if os.path.exists(custom_personality_path):
+    with open(custom_personality_path, 'r') as f:
+        custom_personalities = yaml.safe_load(f) or []
+        PERSONALITY_OPTIONS.extend(custom_personalities)
+
 PERSONALITY_OPTIONS = [{'name': 'LLM Generated', 'prompt': ''}] + PERSONALITY_OPTIONS
 
 class LofnError(Exception):


### PR DESCRIPTION
## Summary
- allow personal profiles in `custom_personalities.yaml`
- document how to create the file
- add example file in `lofn/prompts`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bb61e9d9c832985011f1924943203