### PR TITLE
Add multi-song support

### DIFF
--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -292,6 +292,28 @@ music_gen_schema = {
     "title": str
 }
 
+# New schemas for multi-song workflows
+song_prompts_schema = {
+    "song_prompts": [
+        {"music_prompt": str, "lyrics_prompt": str, "title": str}
+    ]
+}
+
+musician_refined_schema = {
+    "musician_refined_prompts": [
+        {"music_prompt": str, "lyrics_prompt": str, "title": str}
+    ]
+}
+
+final_music_schema = {
+    "revised_prompts": [
+        {"music_prompt": str, "lyrics_prompt": str, "title": str}
+    ],
+    "synthesized_prompts": [
+        {"music_prompt": str, "lyrics_prompt": str, "title": str}
+    ]
+}
+
 
 song_guides_schema = {
     "song_guides": [
@@ -299,11 +321,6 @@ song_guides_schema = {
     ]
 }
 
-music_generation_schema = {
-    "music_prompts": [
-        {"music_prompt": str, "lyrics_prompt": str}
-    ]
-}
 
 # Schema for panel voting on concept-medium pairs
 best_pairs_schema = {
@@ -2033,7 +2050,7 @@ def generate_music_prompts(
 
             status.update(label="Music Prompt Generation Complete!", state="complete")
 
-        return final_output['music_prompt'], final_output['lyrics_prompt'], final_output['title']
+        return final_output
 
     except Exception as e:
         raise LofnError(f"Error in music prompt generation: {str(e)}")
@@ -2092,7 +2109,7 @@ def process_video_artist_refined_prompts(
     style_axes=None,
     model=None
 ):
-    expected_schema = artist_refined_schema
+    expected_schema = musician_refined_schema
     parsed_output = run_llm_chain(
         chains,
         'artist_refined',
@@ -2168,7 +2185,7 @@ def process_music_generation_prompts(
     style_axes=None,
     model=None
 ):
-    expected_schema = music_generation_schema
+    expected_schema = song_prompts_schema
     parsed_output = run_llm_chain(
         chains,
         'generation',
@@ -2213,7 +2230,7 @@ def process_music_artist_refined_prompts(
             "medium": arrangement,
             "facets": facets['facets'],
             "style_axes": style_axes,
-            "music_gen_prompts": [x['music_prompt'] for x in music_prompts['music_prompts']]
+            "song_prompts": music_prompts['song_prompts']
         },
         max_retries,
         model,
@@ -2238,7 +2255,7 @@ def process_music_revision_synthesis(
     style_axes=None,
     model=None
 ):
-    expected_schema = music_gen_schema
+    expected_schema = final_music_schema
     parsed_output = run_llm_chain(
         chains,
         'revision_synthesis',
@@ -2248,7 +2265,7 @@ def process_music_revision_synthesis(
             "medium": arrangement,
             "facets": facets['facets'],
             "style_axes": style_axes,
-            "artist_refined_prompts": [x['artist_refined_prompt'] for x in artist_refined_prompts['artist_refined_prompts']]
+            "artist_refined_prompts": artist_refined_prompts['musician_refined_prompts']
         },
         max_retries,
         model,

--- a/lofn/ui.py
+++ b/lofn/ui.py
@@ -679,27 +679,26 @@ class LofnApp:
             )
             display_temporary_results("Meta Prompt", meta_prompt['meta_prompt'], expanded=False)
             with st.spinner("Generating music prompts..."):
-                music_prompt, lyrics_prompt, music_title = generate_music_prompts(
+                song_prompts = generate_music_prompts(
                     input_text,
                     max_retries=self.max_retries,
                     temperature=self.temperature,
                     model=self.model,
                     debug=self.debug,
                 )
-            st.session_state['music_prompt'] = music_prompt
-            st.session_state['lyrics_prompt'] = lyrics_prompt
-            st.session_state['music_title'] = music_title
+            st.session_state['song_prompts'] = song_prompts
 
-            metadata = {
-                'timestamp': datetime.now(),
-                'title': music_title,
-                'music_prompt': music_prompt,
-                'lyrics_prompt': lyrics_prompt,
-                'input_text': st.session_state.get('input', ''),
-                'competition': True,
-                'model': self.model,
-            }
-            save_music_metadata(metadata)
+            for prompt in song_prompts.get('revised_prompts', []) + song_prompts.get('synthesized_prompts', []):
+                metadata = {
+                    'timestamp': datetime.now(),
+                    'title': prompt['title'],
+                    'music_prompt': prompt['music_prompt'],
+                    'lyrics_prompt': prompt['lyrics_prompt'],
+                    'input_text': st.session_state.get('input', ''),
+                    'competition': True,
+                    'model': self.model,
+                }
+                save_music_metadata(metadata)
             st.success("Music prompts generated successfully!")
             self.display_music_prompts()
         except Exception as e:
@@ -930,7 +929,7 @@ class LofnApp:
             else:
                 self.run_music_competition()
 
-        if 'music_prompt' in st.session_state and 'lyrics_prompt' in st.session_state:
+        if st.session_state.get('song_prompts'):
             self.display_music_prompts()
 
     # def render_music_sidebar(self):
@@ -961,7 +960,7 @@ class LofnApp:
                 )
                 if concept_mediums:
                     first = concept_mediums[0]
-                    music_prompt, lyrics_prompt, music_title = generate_music_prompts(
+                    song_prompts = generate_music_prompts(
                         st.session_state['input'],
                         first['concept'],
                         first['medium'],
@@ -974,20 +973,19 @@ class LofnApp:
                         reasoning_level=st.session_state.get('reasoning_level','medium')
                     )
                 else:
-                    music_prompt = lyrics_prompt = music_title = ""
-            st.session_state['music_prompt'] = music_prompt
-            st.session_state['lyrics_prompt'] = lyrics_prompt
-            st.session_state['music_title'] = music_title
-            metadata = {
-                'timestamp': datetime.now(),
-                'title': music_title,
-                'music_prompt': music_prompt,
-                'lyrics_prompt': lyrics_prompt,
-                'input_text': st.session_state['input'],
-                'competition': False,
-                'model': self.model,
-            }
-            save_music_metadata(metadata)
+                    song_prompts = {'revised_prompts': [], 'synthesized_prompts': []}
+            st.session_state['song_prompts'] = song_prompts
+            for prompt in song_prompts.get('revised_prompts', []) + song_prompts.get('synthesized_prompts', []):
+                metadata = {
+                    'timestamp': datetime.now(),
+                    'title': prompt['title'],
+                    'music_prompt': prompt['music_prompt'],
+                    'lyrics_prompt': prompt['lyrics_prompt'],
+                    'input_text': st.session_state['input'],
+                    'competition': False,
+                    'model': self.model,
+                }
+                save_music_metadata(metadata)
             st.success("Music prompts generated successfully!")
             self.display_music_prompts()
         except Exception as e:
@@ -995,24 +993,36 @@ class LofnApp:
             logger.exception("Error generating music prompts: %s", e)
 
     def display_music_prompts(self):
-        st.subheader("Generated Song Title")
-        st.code(st.session_state['music_title'], language='text')
+        song_prompts = st.session_state.get('song_prompts')
+        if not song_prompts:
+            return
 
-        st.subheader("Generated Music Prompt")
-        st.code(st.session_state['music_prompt'], language='text')
+        st.subheader("Revised Prompts")
+        for prompt in song_prompts.get('revised_prompts', []):
+            st.markdown(f"### {prompt['title']}")
+            st.markdown("**Music Prompt**")
+            st.code(prompt['music_prompt'], language='text')
+            st.markdown("**Lyrics Prompt**")
+            st.code(prompt['lyrics_prompt'], language='text')
+            st.markdown('---')
 
-        st.subheader("Generated Lyrics Prompt")
-        st.code(st.session_state['lyrics_prompt'], language='text')
-        st.info("Copy the above prompts and paste them into Udio to generate your music.")
+        st.subheader("Synthesized Prompts")
+        for prompt in song_prompts.get('synthesized_prompts', []):
+            st.markdown(f"### {prompt['title']}")
+            st.markdown("**Music Prompt**")
+            st.code(prompt['music_prompt'], language='text')
+            st.markdown("**Lyrics Prompt**")
+            st.code(prompt['lyrics_prompt'], language='text')
+            st.markdown('---')
+
+        st.info("Copy any of the above prompts and paste them into Udio to generate your music.")
 
     def initialize_session_state(self):
         default_values = {
             'selected_tab': 'Image Generation',
             'video_concept_mediums': None,
             'video_prompts_df': None,
-            'music_title': None,
-            'music_prompt': None,
-            'lyrics_prompt': None,
+            'song_prompts': None,
             'concept_mediums': None,
             'pairs_to_try': [0],
             'button_clicked': False,


### PR DESCRIPTION
## Summary
- support multiple song prompts for music generation
- update UI to display all revised/synthesized songs
- validate new music schemas across music prompt steps
- fix schema reference for image artist step

## Testing
- `pytest -q`
- `bash examples/cli_smoke_test.sh`


------
https://chatgpt.com/codex/tasks/task_e_687c20d281888329988cfa2084be489b