### PR TITLE
Fix duplicate widget keys in music UI

### DIFF
--- a/lofn/helpers.py
+++ b/lofn/helpers.py
@@ -388,7 +388,18 @@ def display_generation_results(title, data, is_dataframe=False):
     else:
         st.write(data)
 
-def create_mini_dashboard(pairs):
+def create_mini_dashboard(pairs, key_prefix="pair"):
+    """Display concept/medium pairs in a grid of columns with selection checkboxes.
+
+    Parameters
+    ----------
+    pairs : list
+        List of concept/medium dictionaries to display.
+    key_prefix : str, optional
+        Prefix for the Streamlit widget keys so that different dashboards can
+        coexist without key collisions.
+    """
+
     cols = 3
     selected_pairs = []
     for i in range(0, len(pairs), cols):
@@ -403,7 +414,8 @@ def create_mini_dashboard(pairs):
                         medium_key = 'medium' if 'medium' in pair else 'arrangement'
                         st.markdown(f"**Concept:** {pair.get(concept_key)}")
                         st.markdown(f"**Medium:** {pair.get(medium_key)}")
-                    if st.checkbox(f"Select Pair {i+j+1}", key=f"pair_{i+j}"):
+                    checkbox_key = f"{key_prefix}_{i+j}"
+                    if st.checkbox(f"Select Pair {i+j+1}", key=checkbox_key):
                         selected_pairs.append(i+j)
                     st.markdown("---")
     return selected_pairs

--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -2031,22 +2031,89 @@ def generate_music_prompts(
                 )
             }
 
-        with st.status(f"Generating Music Prompts for {concept} in {arrangement}...", expanded=True) as status:
+        with st.status(
+            f"Generating Music Prompts for {concept} in {arrangement}...",
+            expanded=True,
+        ) as status:
             status.write("Generating Facets...")
-            facets = process_facets(chains, input_text, concept, arrangement, max_retries, debug, style_axes, model)
-            display_facets(facets['facets'])
+            facets = process_facets(
+                chains,
+                input_text,
+                concept,
+                arrangement,
+                max_retries,
+                debug,
+                style_axes,
+                model,
+            )
+            if facets is None:
+                raise LofnError("Failed to generate facets")
+            display_facets(facets["facets"])
 
             status.write("Creating Song Guides...")
-            guides = process_song_guides(chains, input_text, concept, arrangement, facets, max_retries, debug, style_axes, model)
+            guides = process_song_guides(
+                chains,
+                input_text,
+                concept,
+                arrangement,
+                facets,
+                max_retries,
+                debug,
+                style_axes,
+                model,
+            )
+            if guides is None:
+                raise LofnError("Failed to generate song guides")
 
             status.write("Generating Music Prompts...")
-            music_prompts = process_music_generation_prompts(chains, input_text, concept, arrangement, facets, guides, max_retries, debug, style_axes, model)
+            music_prompts = process_music_generation_prompts(
+                chains,
+                input_text,
+                concept,
+                arrangement,
+                facets,
+                guides,
+                max_retries,
+                debug,
+                style_axes,
+                model,
+            )
+            if music_prompts is None:
+                raise LofnError("Failed to generate music prompts")
 
             status.write("Refining Prompts...")
-            artist_refined = process_music_artist_refined_prompts(chains, input_text, concept, arrangement, facets, music_prompts, guides, max_retries, debug, style_axes, model)
+            artist_refined = process_music_artist_refined_prompts(
+                chains,
+                input_text,
+                concept,
+                arrangement,
+                facets,
+                music_prompts,
+                guides,
+                max_retries,
+                debug,
+                style_axes,
+                model,
+            )
+            if artist_refined is None:
+                raise LofnError("Failed to refine music prompts")
 
             status.write("Synthesizing Final Prompts...")
-            final_output = process_music_revision_synthesis(chains, input_text, concept, arrangement, facets, artist_refined, guides, max_retries, debug, style_axes, model)
+            final_output = process_music_revision_synthesis(
+                chains,
+                input_text,
+                concept,
+                arrangement,
+                facets,
+                artist_refined,
+                guides,
+                max_retries,
+                debug,
+                style_axes,
+                model,
+            )
+            if final_output is None:
+                raise LofnError("Failed to synthesize final music prompts")
 
             status.update(label="Music Prompt Generation Complete!", state="complete")
 

--- a/lofn/ui.py
+++ b/lofn/ui.py
@@ -380,8 +380,8 @@ class LofnApp:
         # The user’s idea. Tying it to session_state so it does not vanish
         st.subheader("Describe Your Idea")
         st.text_area(
-            label="",
-            label_visibility="collapsed", # hides it visually if desired
+            label="Art Idea",
+            label_visibility="collapsed",  # hides it visually if desired
             key="input",  # This ensures the text stays in st.session_state['input']
             placeholder="Describe the essence of the art you wish to generate.",
             help="Provide a detailed description of your idea to get the best results.",
@@ -504,7 +504,9 @@ class LofnApp:
         st.subheader("Generated Concepts and Mediums")
 
         # Display concepts in a mini-dashboard
-        selected_pairs = create_mini_dashboard(st.session_state['concept_mediums'])
+        selected_pairs = create_mini_dashboard(
+            st.session_state['concept_mediums'], key_prefix="image_pair"
+        )
         st.session_state['selected_pairs'] = selected_pairs
 
         # Buttons to proceed
@@ -770,8 +772,8 @@ class LofnApp:
         st.header("Generate Your Art Video Concept")
         st.subheader("Describe Your Idea")
         st.text_area(
-            label="",
-            label_visibility="collapsed", # hides it visually if desired
+            label="Video Idea",
+            label_visibility="collapsed",  # hides it visually if desired
             key="input",
             placeholder="Describe the essence of the art video you wish to generate.",
             help="Provide a detailed description of your idea to get the best results.",
@@ -878,7 +880,9 @@ class LofnApp:
 
     def display_video_concepts(self):
         st.subheader("Generated Video Concepts and Mediums")
-        selected_pairs = create_mini_dashboard(st.session_state['video_concept_mediums'])
+        selected_pairs = create_mini_dashboard(
+            st.session_state['video_concept_mediums'], key_prefix="video_pair"
+        )
         st.session_state['selected_video_pairs'] = selected_pairs
 
         if st.button("Generate Video Prompts for Selected Concepts"):
@@ -937,7 +941,9 @@ class LofnApp:
 
     def display_music_concepts(self):
         st.subheader("Generated Music Concepts and Mediums")
-        selected_pairs = create_mini_dashboard(st.session_state['music_concept_mediums'])
+        selected_pairs = create_mini_dashboard(
+            st.session_state['music_concept_mediums'], key_prefix="music_pair"
+        )
         st.session_state['selected_music_pairs'] = selected_pairs
 
         if st.button("Generate Music Prompts for Selected Concepts"):
@@ -968,6 +974,10 @@ class LofnApp:
                     creativity_spectrum=st.session_state['creativity_spectrum'],
                     reasoning_level=st.session_state.get('reasoning_level','medium')
                 )
+            if not song_prompts:
+                st.error("Failed to generate music prompts.")
+                return
+
             st.success(f"Music prompts generated for '{pair['concept']}'")
 
             if 'song_prompts' not in st.session_state or st.session_state['song_prompts'] is None:
@@ -1017,8 +1027,8 @@ class LofnApp:
 
         st.subheader("Describe Your Song Idea")
         st.text_area(
-            label="",
-            label_visibility="collapsed", # hides it visually if desired
+            label="Song Idea",
+            label_visibility="collapsed",  # hides it visually if desired
             key="input",
             placeholder="Describe the themes, emotions, and specific elements you want in your song.",
             help="Provide a detailed description of your song idea."
@@ -1104,9 +1114,6 @@ class LofnApp:
                 }
                 save_music_metadata(metadata)
             st.success("Music prompts generated successfully!")
-            self.display_music_prompts()
-            if st.session_state.get('music_concept_mediums'):
-                self.display_music_concepts()
         except Exception as e:
             st.error("An error occurred while generating music prompts.")
             logger.exception("Error generating music prompts: %s", e)


### PR DESCRIPTION
## Summary
- add `key_prefix` argument to `create_mini_dashboard`
- use unique prefixes for image, video and music checkboxes
- avoid double rendering of music dashboard
- handle missing music prompts gracefully
- validate step outputs in music prompt generation
- provide hidden but non-empty labels on text areas

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68803c3887548329b678a9e857ebc61a