### PR TITLE
Use dedicated video frames list

### DIFF
--- a/lofn/helpers.py
+++ b/lofn/helpers.py
@@ -42,6 +42,22 @@ def sample_artistic_frames(min_count: int = 40, max_count: int = 50) -> str:
     return "\n".join(frames)
 
 
+def sample_video_frames(min_count: int = 40, max_count: int = 50) -> str:
+    """Return a newline-separated list of randomly selected video frames."""
+    path = os.path.join(os.path.dirname(__file__), 'prompts', 'video_frames.csv')
+    with open(path, newline='') as csvfile:
+        reader = csv.DictReader(row for row in csvfile if row.strip())
+        rows = list(reader)
+
+    count = random.randint(min_count, max_count)
+    sampled = random.sample(rows, count)
+    frames = [
+        f"{row['Category']}{row['Technique']}{row['Description']}"
+        for row in sampled
+    ]
+    return "\n".join(frames)
+
+
 def sample_music_genres(min_count: int = 40, max_count: int = 50) -> str:
     """Return a newline-separated list of randomly selected music genres."""
     path = os.path.join(os.path.dirname(__file__), 'prompts', 'genres.txt')

--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -29,6 +29,7 @@ from helpers import (
     display_facets,
     display_creativity_and_style_axes,
     sample_artistic_frames,
+    sample_video_frames,
     sample_music_frames,
     sample_music_genres,
 )
@@ -1530,6 +1531,9 @@ def generate_meta_prompt(
         if medium == "music":
             frames_list = sample_music_frames()
             genres_list = sample_music_genres()
+        elif medium == "video":
+            frames_list = sample_video_frames()
+            genres_list = None
         else:
             frames_list = sample_artistic_frames()
             genres_list = None

--- a/lofn/prompts/video_frames.csv
+++ b/lofn/prompts/video_frames.csv
@@ -1,0 +1,1273 @@
+Category,Technique,Description
+Neoplastic Remnants,Offset Rectangles,Slightly misaligned rectangles of pure color forming a puzzle
+Neoplastic Remnants,Bold Vertical Divider,A single thick vertical line slicing down the frame
+Mandala Worlds,Ornate Circular Labyrinth,A labyrinthine circle reminiscent of ancient designs
+Architectural,Doorway Composition,Using architectural doorways as frames
+Abstract,Shape Overlay,Using geometric overlays as frames
+Celestial Wonders,Comet Tail Sweep,A dynamic swoosh reminiscent of a comet’s tail crossing the border
+Obscure & Avant-Garde,Feather Inked Mandala,Circular arrangement of feathers and ink patterns combined
+Anime Fusion,Magical Girl Ribbon,Flowing pastel ribbons swirling around the subject
+Natural Framing,Mountain Pass,Using valley walls as natural vertical frames
+Subterranean Myths,Worm Tunnel Spirals,"Strange, winding tunnels reminiscent of giant burrowing creatures"
+Obscure & Avant-Garde,Psychedelic Serpent Coil,A serpent border twisting in a swirl of shifting neon patterns
+Light Play,Fiber Optic Edge,Light-conducting materials as frame borders
+Zen Minimalism,Soft Brush Ink Circle,"A single, broad brushstroke circle partially framing the subject"
+Fragmented Realities,Data Block Rift,"Cubical data blocks misaligned, forming a glitch rift in the center"
+Mandala Worlds,Sacred Geometry Web,Interlocking geometric forms swirling around edges
+Polyptych,Triptych Classic,Splitting image across three balanced panels
+Magical Realism,Underwater Sky Reflection,"Upside-down water reflection at the top, as if the sky is an ocean"
+Silent Cinematic,Clapperboard Corners,Old-fashioned clapperboards at diagonal corners
+Destructive,Bullet Hole Patterns,Multiple bullet-like punctures arranged as an aggressive frame
+Dream Collisions,Pillow Castle Turrets,Fluffy castle towers made of pillow-like materials
+Human Elements,Portrait Profile,Using facial profiles as side frames
+Composite,Time Slice,Using multiple time frames as borders
+Mystical Folklore,Wisp Lanterns,Floating orbs of light like will-o’-the-wisps lighting the corners
+Zen Minimalism,Monochrome Water Ripple,"Concentric circles in calm water, barely visible near corners"
+Aqueous Vision,Drifting Jelly Aureole,Wispy jellyfish tentacles forming a translucent halo
+Cyber Tribal,Digi-Totem Poles,Vertical stacks of circuit boards arranged like tribal totems
+Silent Cinematic,Sepia Tonal Vignette,A subtle brownish fade reminiscent of early cinema
+Architectural,Ornate Portal,Incorporating highly decorative or carved doors as a dramatic frame
+Modern Kitsch,Psychedelic Leopard Print,"Leopard spots in bright, clashing colors forming a tacky-cool boundary"
+Myth-Punk Fusion,Dragonfly Cog Wings,Delicate insect wings adorned with tiny rotating cogs
+Silent Cinematic,Silent Title Cards,Stylized black title cards at the top and bottom corners
+Space Opera,Galactic Royal Banner,"Regal, futuristic banners with star insignias draped at corners"
+Natural Framing,Rock Formation Frame,Using natural rock formations to create boundaries
+Retro-Futurism,Laser Grid Overlay,Thin neon beams forming a 3D grid above the subject
+Obscure & Avant-Garde,Architectural Hallucination,Escher-like staircases that ascend and descend unpredictably at the margins
+Industrial Grunge,Rusted Chain Link,A gritty border of rusted metal links encircling the subject
+Tactile Sensations,Woolen Knit Border,Cozy knitted texture wrapping the subject with warmth
+Aerial Whimsy,Umbrella Sky,Multiple umbrellas carried by the wind overhead
+Ceremonial,Chalice Arc,"An arc or cup-like shape referencing ceremonial vessels, curving around the focal point"
+Texture Effects,Letterpress,Simulated pressed ink and debossing effect
+Magical Realism,Otherworldly Clock Face,"A faint, floating clock with shifting numbers forming a ghostly ring"
+Arcane Runes,Spiral Sigil Chains,"Linked sigils spiraling from each corner, weaving together"
+Experimental,Paint Splash,Using liquid paint as abstract frame elements
+Speculative Plastics,Resin Drip Border,Semi-transparent resin dripping from the top in smooth ribbons
+Industrial Grunge,Corroded Iron Gate,"A battered iron gateway silhouette, partially open around the subject"
+Eco-Conscious,Bio-Lattice,Interlocking hexagons of living moss or microflora around the image
+Negative Shadow,Shadow Mosaic Pieces,Small shadow shapes fitting together like puzzle tiles
+Gritty Noir,Venetian Blind Stripes,High-contrast slats of light cutting across the border
+Human Elements,Portrait Profile,Using facial profiles as side frames
+Strange Anthropomorphism,Talking Teapot Spout,Teapots with expressive spouts forming a chatty ring
+Experimental Expression,Melanin Print Transfer,Skin-contact prints forming unique organic textures
+Spiral Biomes,Volcanic Twister,Ash and fire swirling in a tornado-like pattern at the edges
+8-Bit Style,Tile Set Border,Using game tile patterns as decorative frames
+8-Bit Style,Glitch Pattern Border,Using controlled pixel glitches as frame elements
+Obscure & Avant-Garde,Atlas Spine,"The silhouette of a curved human spine, stylized with topographic lines"
+Human Elements,Eye Reflection,Using eye close-ups as natural frames
+Experimental,Fabric Flow,Using flowing fabric as dynamic frame elements
+Obscure & Avant-Garde,Psychic Vapor Heads,Transient silhouettes of faces forming gaseous illusions at the margins
+Material Fusion,Rust Development,Controlled oxidation patterns in metal
+Natural Framing,Waterfall Curtain,Using falling water as a dynamic frame
+Obscure & Avant-Garde,Static Frequency,"A ghostly line pattern that resembles old TV static, but shifting unpredictably"
+Composite,Digital Overlay,Using digital elements as frame borders
+Light Techniques,Lens Flare Frame,Using controlled lens flare as frame elements
+Composite,Image Within Image,Creating recursive frame patterns
+Esoteric Botany,Diagrammatic Flower Sections,Scientific cross-sections of flowers repeated like blueprint margins
+Anthropomorphic Auras,Whispering Figures,Faint figure outlines appearing to whisper secrets along the frame
+Mythical Cyberpunk,Hive City Skyline,"A sprawling, layered city in neon silhouettes"
+Mythic Realism,Elemental Crest,"A crest-like heraldry featuring earth, wind, fire, and water framing corners"
+Obscure & Avant-Garde,Glitchy Feather Fringe,Bird feathers intermittently pixelating at the edges
+Human Elements,Group Circle,Using circular human formations as frames
+Arcane Runes,Orbital Rune Rings,Concentric rings of magical glyphs orbiting the central space
+Obscure & Avant-Garde,Translucent Beetle Wings,Delicate insect wing veils with subtle iridescent veins
+Obscure & Avant-Garde,Holographic Lattice,Gridlines of refracted light forming a 3D cage around the focal area
+Fractal Universe,Julia Lace,Delicate lace-like fractal motifs spiraling from corners
+Speculative Biotech,Cybernetic Tendrils,Vine-like cables or wires creeping in a living-meets-machine vibe
+Ancient Algorithm,Clay Tablet Code,Cuneiform-like inscriptions arranged in meticulous columns
+Speculative Plastics,Vacuum-Formed Bubble,Slightly inflated plastic bubbles overlapping at corners
+Human Elements,Joined Arms Arch,Multiple arms raised and interlinked overhead to create an arch
+Senses Amplified,Echo Ripple Border,"Visual “sound waves” radiating outward, evoking an audio-like resonance"
+Micro-Macro Fusion,Atom Orbit Lines,Thin orbital paths around the subject mimicking electron movement
+Space Opera,Com Badge Cluster,Futuristic communication badges repeated around the perimeter
+Neo Symbolic,Cube of Metatron,A 3D twist on the classic Metatron’s Cube in neon lines
+Destructive,Ash Fragmented Edge,Layering ashes or soot to appear crumbled at the perimeter
+Vaporwave Essence,Grid Horizon Band,Retro 80s neon grid lines forming a horizontal band at the bottom
+Architectural,Column Framing,Using vertical columns to create side frames
+Light Techniques,Lightning Flash Outline,Capturing a momentary frame with natural lightning in the background
+Obscure & Avant-Garde,Abyssal Porthole,A deep void ringed by swirling tentacles from an unseen ocean trench
+Color Effects,Selective Color,Isolating and enhancing specific color ranges
+Painted Illusions,Trompe-l’œil Tear,"Edges painted to look torn or folded, revealing a hidden layer"
+Material Fusion,Sand Erosion,Using sand-blasted textures and patterns
+8-Bit Style,Loading Bar Frame,Using progress bars as bottom frame elements
+Organic Sci-Fi,Crystalline Stem Cells,Small crystal clusters shaped like embryonic cells
+Natural Framing,Cloud Formation,Using cloud patterns as natural top frames
+Incandescent Symbolism,Lava Engraved Icons,Symbols carved in molten rock with a bright red glow
+Speculative Plastics,Injection Mold Lines,Visible mold parting lines that piece together a synthetic frame
+Paleo-Futuristic,Fossilized Robot Parts,Mechanical remains encased in stonelike textures
+Twisted Cartography,Topographic Warp Lines,"Contour lines that swirl unnaturally, forming a disorienting perimeter"
+Obscure & Avant-Garde,Prismatic Vapor Trails,Rainbow vapor drifts crossing each corner in fluid curves
+Space Opera,Interstellar Mothership,Gigantic spacecraft outline looming behind the subject
+Art Brut Chaos,Chaotic Stitch Patch,Messy thread stitches connecting small torn fabric pieces
+Chromatic Shatter,Liquid Rainbow Drip,Slow-moving drips of multi-hued liquid forming dynamic edges
+Architectural,Bridge Structure,Using bridge elements to create frame boundaries
+Arcane Runes,Blood Ink Scripts,"Dark red calligraphy in twisting, arcane lines"
+Ethereal Ruins,Mist-Wrapped Pillars,"Columns wrapped in swirling mist, partially obscured"
+Obscure & Avant-Garde,Digital Stained Wax,Melting wax lumps with glitchy pixel shifts in color
+Urban Street Graffiti,Paint Drip Cascade,Layers of vibrant paint dripping downward along the edges
+Polyptych,Fibonacci Sequence,Panel sizes following golden ratio
+Material Fusion,Living Wall Frame,Incorporating growing plants into frame
+Mythical Cyberpunk,Shinto Gate Surge,Traditional shrine gates crackling with electronic arcs
+Dreamlike Collisions,Upside-Down Tree Blossoms,"Roots in the sky, blooms near the bottom border"
+Sculptural,Floating Suspension,Invisible support systems
+Celestial Decadence,Comet Tiaras,Small comet trails arching overhead like a series of tiaras
+Obscure & Avant-Garde,Fluid Collagraph,Embossed shapes with swirling colored inks like a watery printmaking technique
+Modern Kitsch,Cheesy Paparazzi Flash,Cartoonish camera flashes like celebrity photography bursts
+Abstract,Neon Minimal Blocks,Simple neon squares or rectangles placed at strategic angles to form a frame
+Polyptych,Quadriptych Grid,Four-panel arrangement in square format
+Polyptych,Pentaptych Arc,Five-panel curved arrangement
+Modern Kitsch,Glitter Confetti Scatter,Holographic sparkles tossed around the perimeter
+Biomorphic Patterns,Celestial Butterfly Wings,Butterfly wings with starry patterns extended from each corner
+Experimental,Water Droplet,Using macro water drops as natural lenses
+Cyber Tribal,Hybrid Circuit Drums,Circular drum shapes with embedded circuitry wrapping corners
+Subterranean Myths,Deep Echo Chambers,Resonating ring shapes as though from far below the earth
+Surreal Horizons,Opalescent Horizon Glaze,"A shimmering, pearl-like film across the horizon creating a radiant frame"
+Twisted Cartography,City Grid Tangle,A labyrinth of streets twisting beyond normal geometry
+Folk Art Revival,Folk Doodle Vine,"Hand-drawn, vine-like doodles curling around the margin"
+Experimental,Mirror Fragments,Using broken mirror pieces as frame elements
+Organic Sci-Fi,Liquid Metal Roots,Mercury-like fluid forming root systems creeping in from corners
+Neo-Shamanic,Spirit Mask Frieze,"Repeating carved masks with swirling, smoke-like spirit lines"
+Composite,Scan & Print Mix,Layering scanned textures over a digital background to create a unique perimeter
+Obscure & Avant-Garde,Aqua Dream Foam,"A borderline of dreamy, frothy water with iridescent highlights"
+Mandala Worlds,Lotus Petal Radials,Circular lotus petal designs fanning out around the center
+Incandescent Symbolism,Lightning Seal,A ring of contained lightning arcs zipping around the subject
+Experimental,UV Paint Edges,Applying ultraviolet paint that glows at the margins under black light
+Human Elements,Crowd Frame,Using people groups as natural frames
+Mythical Cyberpunk,Holo Kanji Tattoo,Holographic Japanese characters vertically aligned at the sides
+Human Elements,Dance Motion,Using movement blur as dynamic frames
+Neoplastic Remnants,Constructivist Angles,"Angular shapes in strong contrast, reminiscent of early modern design"
+Obscure & Avant-Garde,Dripping Op Art,Optical illusions with stripes that drip downward like paint
+Obscure & Avant-Garde,Stitched-Together Fragments,Sewing-thread seams uniting mismatched patches of texture
+Paper Texture,Chain and Laid,Linear grid-like pattern visible when held to light
+Gritty Noir,Cigarette Smoke Frame,Wispy plumes of smoke swirling heavily around the perimeter
+Random Obscura,Wax Crayon Scrawls,Childlike scribbles layered in bright waxy colors
+Anthropomorphic Auras,Body Map Outline,Human muscle or nervous system outlines layered along the border
+Experimental,Bubble Wrap Pane,"Placing bubble wrap in front of the lens for a warped, dotted effect"
+Paleo-Futuristic,Stone Wheel Circuit,Primitive stone wheels with embedded circuit lines
+Destructive,Strategic Tearing,Calculated paper tearing for organic edges
+Obscure & Avant-Garde,Luminescent Moss Embroidery,An embroidered effect of glowing lichen forming an ornate border
+Pastel Macabre,Haunted Macaron Towers,Stacks of pastel macarons with subtle ghost faces drifting upward
+Celestial Decadence,Stardust Barrette,Hairclip-like ornamental frames made of twinkling stardust
+Human Elements,Headphone Cords,People holding headphone wires or cables that weave around the perimeter
+Random Obscura,Elastic Rubber Bands,"Colorful, stretched rubber bands stacked and overlapping at the perimeter"
+Anime Fusion,Manga Panel Collage,Multiple comic panels offset around the perimeter
+Twisted Cartography,Inverted Mountain Range,"Peaks hanging from the top border, flipping standard orientation"
+Subterranean Myths,Crystal Stalagmite Gate,Glittering spires of crystal rising from the bottom corners
+Obscure & Avant-Garde,Soundwave Lace,Intricate lace patterns derived from captured audio waveforms
+Aerial Whimsy,Bird Silhouette Chain,Linked silhouettes of birds in flight across the edges
+Obscure & Avant-Garde,Paper Wolf Cutout,Hand-torn edges arranged to create the silhouette of a howling wolf
+Obscure & Avant-Garde,Splintered Ink Rune,Jagged black ink lines forming cryptic runes along the edges
+Obscure & Avant-Garde,Liquid Metal Cascade,"Mercurial rivulets streaming at the margins, continuously shifting form"
+Dream Collisions,Feather-Cloud Merge,"Soft plumes that seem part feather, part cloud, drifting at the edges"
+Composite,Collage Border,Using multiple images as frame elements
+Experimental,Chemical Reaction Patterns,Capturing crystallization or chemical bloom as a fractal frame
+Material Fusion,Leather-Bound Edge,Stitched leather corners combined with another substrate
+Twisted Cartography,Ocean Rift Patterns,Seafloor ridges arching across the margin like cracks
+Artistic Effects,Paint Splash,Dynamic liquid paint elements
+Space Opera,Space Debris Field,Shattered satellite pieces and cosmic junk swirling
+Digital Effects,Scan Lines,CRT screen effect overlay
+Arcane Runes,Sealed Circle Ward,A protective circle with runic wards capping each corner
+Urban Street Graffiti,Neon Spray Fade,Gradual fade from vibrant neon spray patterns to the focal area
+Human Elements,Body Silhouette,Using human forms as frame elements
+Interstellar Dreamscapes,Crystallized Moon Shards,Fragmented moon pieces refracting cosmic light along the borders
+Obscure & Avant-Garde,Electric Lotus,Lotus petals crackling with electric arcs
+Organic Sci-Fi,Bio-Steel Vines,Mechanical vines with a fibrous metallic sheen coiling around the frame
+Destructive,Scratched Emulsion,Film-like scratches or distressed marks across the border
+Obscure & Avant-Garde,Serpentine Infinity,Two coiling serpents forming a figure-eight at opposite edges
+Pastel Macabre,Candy-Wrapped Coffins,Mini coffins in playful candy wrappers repeated along the frame
+Paleo-Futuristic,Stone Pylon Broadcast,Large standing stones that emit holographic signals
+Strange Anthropomorphism,Wall Clock Expression,Clock faces with eyebrows and mustaches forming comedic characters
+Fractal Universe,Mandelbrot Rings,Concentric fractal loops reminiscent of the Mandelbrot set
+Abstract,Polychrome Tessellation,Repeated polygon shapes in multiple colors forming a border
+Modern Kitsch,Plastic Flamingo Corners,Pink flamingo lawn ornaments perched on each corner
+Silent Cinematic,Flickering Subtitle Bar,A small bar with silent era typography flickering below
+Incandescent Symbolism,Neon Sigil Repeat,Glowing sigils repeated in neon lines around the edges
+Ethereal Ruins,Crumbled Dome Silhouette,A faint outline of a grand dome partially broken at the top
+Zen Minimalism,Single Bamboo Stalk,A lone bamboo shoot growing vertically at the side
+Human Elements,Dance Motion,Using movement blur as dynamic frames
+Color Effects,Oxide Staining,Creating rust-like organic patterns
+Retro-Futurism,Purple Haze Fade,Bright ultraviolet fade from corners toward the center
+Celtic Revival,Triskelion Swirl,Three-spiraled symbol repeated in a wave around the edges
+Obscure & Avant-Garde,Floating Tarot Arc,Archetypal tarot imagery forming an archway at the top
+Obscure & Avant-Garde,Spectral Vellum,Ghostly translucent parchment corners that fade in and out
+Material Fusion,Melted Wax Overlay,Dripping wax layers fused with another material around the edges
+Mystical Folklore,Totem Animal Guardian,Ancestral animal shapes perched as protective watchers at the edges
+Tech-Decay Chic,Rust & Circuitry,Blending corroded metal textures with glitchy circuit board traces
+Magical Realism,Rainbow Vine,A single vine with rainbow leaves winding across the border
+Negative Shadow,Cutout Silhouette Panels,Panels of negative space shaped like mysterious figures
+Hippie Psychedelia,Freeform Tie-Dye Waves,Flowing tie-dye colors swirling like a kaleidoscope at the edges
+Hippie Psychedelia,Rainbow Paisley,"Flowing, teardrop paisley patterns in bright rainbow hues"
+Retro-Spiritual,Groovy Lotus Petals,"Stylized lotus petals in swirling, swirling tie-dye colorways"
+Composite,Dual Theme Juxtaposition,"Combining drastically different motifs (e.g., desert + ocean) around edges"
+Light Techniques,Light Beam Frame,Using visible light beams as natural frames
+Experimental,Elastic Snap Lines,Using stretched rubber or latex lines that snap to create interesting lines or shapes
+Polyptych,Nested Triptych,Frames within frames in three sections
+Composite,Collage Border,Using multiple images as frame elements
+Art Brut Chaos,Unrefined Brush Splat,"Large, unpolished brush swaths in raw color"
+Folk Art Revival,Paper Cut Folk Silhouettes,Delicate paper silhouette cut-outs of animals or people
+Natural Framing,Sand Dune Lines,Using desert formations as natural leading lines
+Speculative Plastics,Plastic Filament Weave,3D-printed filaments woven into a net-like boundary
+Texture Effects,Paper Texture,Adding subtle grain and material feel
+Architectural,Skylight Halo,Positioning a subject beneath a circular or geometric skylight
+Color Effects,Gradient Overlay,Smooth color transitions across design
+Wabi-Sabi Aesthetic,Kintsugi Fracture,Cracked edges “repaired” with gold lines symbolizing beauty in imperfection
+Obscure & Avant-Garde,Grand Bazaar Collage,Torn scraps of exotic rugs and textiles arranged in a patchwork border
+Silent Cinematic,Film Reel Strip,A horizontal film strip with perforations along the edge
+Paleo-Futuristic,Ancient Tech Carvings,Geometric carvings resembling high-tech schematics on cave walls
+Urban Street Graffiti,Tag Signature Border,Dozens of stylized graffiti tags scrawled around the perimeter
+Industrial Grunge,Warning Tape X,Bright hazard tape arranged in an X shape as a bold frame
+Human Elements,Shadow People,Using human shadows as frame elements
+Gritty Noir,Shadow Alley Silhouette,An alley viewpoint with high walls of shadow creeping inward
+Retro-Futurism,Holographic Diamond,Rotating diamond shapes with shining edges framing the scene
+Gritty Noir,Rain-Soaked Window,Beads of water on glass revealing the scene in partial clarity
+Abstract,Pattern Break,Using pattern interruption as frames
+Mythical Cyberpunk,Urban Katana Shard,Slivers of a digital blade glitching in from corners
+Obscure & Avant-Garde,Planchette Aperture,"Spirit board planchettes arrayed around the edges, hinting at esoteric forces"
+Subterranean Myths,Underground City Silhouette,Faint outlines of lost civilizations carved into the cave sides
+Obscure & Avant-Garde,Digital Roots,Circuit-like roots branching from corners as if searching for sustenance
+Tactile Sensations,Bubble Foam Edge,Clusters of foam bubbles forming gentle orbs
+Obscure & Avant-Garde,Multi-Eyed Creature Border,"A ring of surreal eyeballs blinking, each with a different iris"
+Mythic Realism,Divine Vortex,An atmospheric swirl evoking heavenly or otherworldly portals
+Random Obscura,Sound Tube Burst,Hand-drawn waveforms shaped like tubes exploding outward
+Interstellar Dreamscapes,Nebula Swell,"Billowing cosmic clouds forming a luminous, swirling margin"
+Arcane Runes,Occult Geometry,"Interlocking triangles, squares, and circles with hidden sigils"
+Destructive,Controlled Burning,Strategic charring for edge effects
+Architectural,Ruined Wall Aperture,Capturing the subject through a worn or partially collapsed wall opening
+Painted Illusions,3D Dripping Paint,Illusory paint drips reaching out into three-dimensional space
+Embodied Dreams,Sleepwalker Cloud,A faint figure walking on clouds at the border
+Interstellar Dreamscapes,Planetary Ring Cross,"Thin planetary rings crossing the foreground, partial orbits visible"
+Subterranean Myths,Lava Tube Glow,Molten light seeping through cracks in the rocky edges
+Vector Style,Path Outline Frame,Using stroke paths as frame elements
+Material Fusion,Rust Development,Controlled oxidation patterns in metal
+Subterranean Myths,Mineral Vein Lace,Sparkling veins of precious metals threading through the border
+Modern Kitsch,Smiley Face Polka,Repeating yellow smiley faces in varying sizes around the margin
+SteamPunk Gears,Piston Grid,A repeating pattern of pistons and valves along the borders
+Human Elements,Body Silhouette,Using human forms as frame elements
+Abstract,Layered Color Swatches,Rectangles or circles of varying colors stacked around the edges
+Dreamlike Collisions,Marble Stair Cascade,Ornate marble steps cascading diagonally through the border
+Sculptural,Relief Extension,3D elements extending from frame
+Urban Street Graffiti,Bubble Letter Bomb,Huge bubble letters exploded around the corners
+Zen Minimalism,Sparse Cherry Blossom,Just a few petals drifting in from one corner
+Natural Framing,Foliage Window,Creating viewports through dense vegetation
+Color Effects,Color Bleed,Intentional color bleeding between elements
+Natural Framing,Snowdrift Overhang,Carving or locating a snow overhang to envelop the subject in a white arc
+Architectural,Glass Facade Reflection,Utilizing mirrored windows to frame and reflect the scene
+Dreamlike Collisions,Floating Piano Keys,Keyboard segments drifting like stepping stones
+Art Brut Chaos,Fingerpaint Frenzy,"Smudged, hand-pressed smears reminiscent of preschool art"
+Chromatic Shatter,Reflective Diamond Edge,Sequined diamond shapes reflecting bursts of color
+Architectural,Support Beam Grid,Using industrial beams or scaffolding to create a rigid grid around the subject
+Human Elements,Shadow People,Using human shadows as frame elements
+Mythic Realism,Dragon Spine Border,Scaled ridges weaving along the edges like the spine of a mythical beast
+Material Fusion,Rubber & Alloy Layer,Thin rubber sheeting fused with metal alloy plating
+Obscure & Avant-Garde,Recursive Doodle Maze,Hand-drawn labyrinth lines that replicate infinitely near the edges
+Psychic Impressionism,Emotive Paint Splat,Randomly placed paint splashes that mirror internal feelings
+Material Fusion,Sand Erosion,Using sand-blasted textures and patterns
+Esoteric Botany,Alchemical Herb Stamps,Vintage herbal stamps with cryptic alchemical notations
+Cyber Baroque,Hovering E-Putty Sculptures,"Shapeless digital lumps molded like baroque sculptures, floating at the border"
+Spiral Biomes,Icy Gyre Rings,Translucent frosty rings layered in a swirling arrangement
+Strange Anthropomorphism,Chair Back Faces,Chair backs that morph into abstract faces with subtle expressions
+Paleo-Futuristic,Primitive Ray Gun,A cruder version of a laser weapon repeated at corners
+Architectural,Tunnel Perspective,Using tunnel structures for depth framing
+Ceremonial,Stained Glass Halo,A luminous halo effect with colorful stained glass motifs radiating outward
+Destructive,Water Damage,Intentional water effects for texture
+Celestial Decadence,Opulent Cloud Thrones,Cloud formations shaped like luxurious thrones in each corner
+Light Play,Smoke Screen Dynamic,Controlled smoke as ethereal frame elements
+Ceremonial,Ritual Circle Frame,A circular ring reminiscent of ancient ceremonies to enclose artwork in a sacred spotlight
+Negative Shadow,Obsidian Glow Edge,"A nearly black, glossy frame that reveals subtle reflections"
+Sculptural,Kinetic Movement,Frames with moving elements
+Light Play,Dappled Forest Glow,Sunlight shining through leaves to create flickering spots of illumination
+Material Fusion,Magnetic Field,Using ferrofluid for dynamic borders
+Surface Effects,Watercolor Tooth,Textural surface for paint absorption
+Twisted Cartography,Distorted Compass Rose,An abstract compass rose bending in multiple directions
+Color Surreality,Festival Confetti Streams,Long strips of color confetti fluttering in arcs around the frame
+Aerial Whimsy,Paper Plane Swarm,Tiny folded planes flying diagonally from corner to corner
+Sculptural,Negative Space,Using absence as frame element
+Artistic Effects,Brush Stroke,Hand-painted textural elements
+Architectural,Doorway Composition,Using architectural doorways as frames
+Abstract,Contour Outline Bands,Concentric outlines that mimic topographic or ring-like shapes
+Ancient Algorithm,Golden Ratio Spiral Carving,A stylized Fibonacci spiral carved into a ring
+Obscure & Avant-Garde,Puppeteer’s Hands,"Giant hands at the upper border, as if manipulating the entire scene"
+Retro-Futurism,Retro Tech Panels,Panels reminiscent of old control boards blinking in neon
+Cyber Tribal,Augmented Reality Glyphs,Floating tribal glyphs visible in a digital overlay
+8-Bit Style,Pixel Border Frame,Using chunky pixel edges as retro-style frames
+Destructive,Burn-Through Edge,Controlled burning patterns in frame material
+Tapestry Style,Ornate Gold Frame,Traditional elaborate golden frame style
+Mystical Folklore,Ancient Drum Beat,Rhythmic wave patterns reminiscent of folkloric drumming
+Architectural,Tunnel Perspective,Using tunnel structures for depth framing
+Hippie Psychedelia,Floral Sixties,Bold daisies and groovy shapes radiating outward
+Vaporwave Essence,Sunset Palms,Silhouettes of palm trees in gradient pink and purple around the edges
+Experimental,Thread Cross,Using suspended threads for subtle framing
+Organic Sci-Fi,Spore-Driven Circuits,Circuit boards sprouting fungal spores that light up
+Destructive,Scratched Surface,Creating texture through controlled scratching
+Fragmented Realities,Transparent Pixel Scramble,Sections pixelated in transparent ghost squares
+Biomorphic Patterns,Coral Maze,Intricate coral-like branching forming a labyrinthine margin
+Luminescent Physics,Prism Ring Diffraction,Colorful diffraction patterns forming a circular ring
+Organic Sci-Fi,Living Fiber Optics,Glowing tendrils that look both organic and technological
+Psychic Impressionism,Vibrational Brush Strokes,"Loose, wavy paint strokes that emanate energetic vibrations"
+Celestial Decadence,Golden Star Crown,Rich gold filigree shaped like a star-laden crown at the top
+Obscure & Avant-Garde,Eclipse Eyelets,"Tiny orbs stacked in rows, each a miniature eclipse in progress"
+Obscure & Avant-Garde,Clocktower Aperture,"Gothic clock faces at each corner, each telling a different time"
+Exoplanet Surfaces,Exotic Crystal Outcrops,Bizarre crystals jutting in alien geometry
+Architectural,Urban Canyon,Using tall buildings as vertical frame elements
+Urban Street Graffiti,Stencil Face Repeats,Repeating masked faces as a chaotic graffiti motif
+Magical Realism,Tree of Light,A glowing tree whose branches curve to frame the subject
+Color Effects,Gradient Texture,Combining color fade with surface texture
+Retro-Futurism,Chrome Sphere Corners,Shiny metallic spheres floating near each corner reflecting neon lines
+Composite,Newspaper Column Strips,Vertical columns of text or headlines forming a textual frame
+Obscure & Avant-Garde,Zero-Dimension Pulse,A glowing ring that expands and contracts in irregular intervals
+Obscure & Avant-Garde,Exoskeleton Blossom,Bone-like structures blossoming outward in radial symmetry
+Color Surreality,Gradient Geode,"A layered, gem-like gradient encrusting the border edges"
+Urban Street Graffiti,Paste-Up Poster Peel,Layers of street posters peeling away to reveal the central image
+Material Fusion,Glass Brick Inlay,Blocks of decorative glass bricks built into the structure
+Natural Framing,Canopy Light Pockets,Capturing pockets of dappled light through dense leaf canopies
+Light Play,Overhead Candle Glow,Suspending candles above so that soft flickering glows outline the top
+Cyber Baroque,Augmented Reality Garland,A wearable digital garland overlay that frames the subject in ornate code patterns
+Micro-Macro Fusion,Molecular Ring,A ring of molecule-like shapes bridging science and aesthetics
+Neo-Shamanic,Rune Smoke Trails,Tendrils of smoke forming cryptic runes wafting from each border edge
+Wabi-Sabi Aesthetic,Faded Calligraphy Border,Barely legible brush script worn by time
+Ethereal Ruins,Translucent Marble Walls,Walls that fade into transparency near the corners
+Light Techniques,Spotlight Frame,Using focused light to create natural vignettes
+Obscure & Avant-Garde,Liquid Obsidian Flow,A glossy black fluid with swirling patterns reminiscent of volcanic glass
+Paleo-Futuristic,Dinosaur Exosuit Bones,Fossil frames shaped into advanced exoskeletal suits
+Mythic Realism,Phoenix Embers,Soft glow and drifting sparks that hint at fiery rebirth around the subject
+Dystopian Retro,Overlapped Nuclear Warnings,Repeating hazard symbols forming a cautionary border
+Obscure & Avant-Garde,Neo-Geo Blossom,Sharp geometric petals layered like a futuristic flower
+Chromatic Shatter,Iridescent Ripple,Oil-slick style swirling colors lapping at the edge
+Obscure & Avant-Garde,Alien Crop Circle,"Circular markings reminiscent of farmland patterns, but afloat at the corners"
+Experimental,Glass Shatter,Using controlled glass breaks as frames
+Speculative Plastics,Acrylic Confetti,Multicolored acrylic scraps sprinkled around the perimeter
+Abstract,Motion Blur,Using movement as dynamic frames
+Cyber Baroque,3D Laser Filigree,"Complex, laser-etched designs that hover like holograms around the edges"
+Negative Shadow,Phantom Profile Fade,Barely-there profiles in shadowed grayscale softly overlapping
+Color Surreality,Diffuse Rainbow Mists,"Soft, diffuse rainbow mists drifting in unpredictable shapes"
+Arcane Runes,Glowing Futhark Frame,Runic inscriptions glowing softly around the margins
+Material Fusion,Fabric-Metal Weave,Interlacing strips of fabric with thin metal filaments
+Embodied Dreams,Leg Ladder Rungs,Elongated legs forming ladder rungs up each side
+Mystical Folklore,Fairy Ring Aperture,A ring of tiny mushrooms encircling the central focal point
+Print Effects,Misregistration,Intentional color layer misalignment
+Myth-Punk Fusion,Brass Griffin Crest,A stylized griffin made of brass plates perched at the top
+Composite,Digital Overlay,Using digital elements as frame borders
+Twisted Cartography,Spiral Country Outlines,National borders coiled into bizarre spiral shapes
+Incandescent Symbolism,Illuminated Halo Script,Circular text glowing like a ring of holy light
+Tech-Decay Chic,Rust & Circuitry,Blending corroded metal textures with glitchy circuit board traces
+Light Techniques,Fire Frame,Using flame or ember effects as dynamic frames
+Experimental,Bubble Frame,Using soap bubbles as ethereal frames
+Micro-Macro Fusion,Galaxy Spiral Overlay,A cosmic spiral motif superimposed as a swirling grand-scale border
+Ceremonial,Ritual Circle Frame,Using a circular ring reminiscent of ancient ceremonies to enclose the subject in a sacred spotlight
+Abstract,Texture Border,Using material textures as frame elements
+Color Surreality,Rainbow Drip Horizon,A horizon line dripping in a rainbow spectrum
+Modern Kitsch,Cocktail Umbrella Trim,Tiny paper umbrellas spaced around the edges
+Light Play,Gobo Pattern Wash,Shapes or cutouts placed over a spotlight to cast specific patterns
+Tech-Decay Chic,Terminated Bot Shell,Parts of a dismantled robot forming an industrial collage at the edges
+Space Opera,Planetary Multi-Orbit,Three or more planets orbiting in parallel rings near corners
+Surreal Puppetry,Articulated Joint Frame,Wooden puppet joints pinned in a ring around the center
+Vector Style,Bezier Border,Smooth curved vector paths as frame elements
+Architectural,Catwalk Angles,Composing the shot through overhead catwalk bars for interesting geometry
+Dystopian Retro,Gas Mask Shroud,Faint outlines of gas masks around corners for a post-apocalyptic feel
+Experimental Expression,Motion Capture Lines,Ethereal lines tracking hypothetical movement around the edges
+Composite,Image Within Image,Creating recursive frame patterns
+Experimental,Crinkle Texture,Strategic paper crinkling for dimensional effect
+Zen Minimalism,Quiet Mossy Stones,Smooth stones with sparse moss at the bottom edge
+Myth-Punk Fusion,Rivet-Scaled Dragon,A dragon silhouette with riveted metal plating for scales
+Destructive,Wire Mesh Tear,Ripped wire mesh or chain link partially covering the edges
+Celtic Revival,Braided Serpent Border,Two serpents braided together in an unbroken loop
+Light Techniques,Star Filter Sparkles,Using a starburst filter to generate sparkly points of light as a frame
+Ancient Algorithm,Mechanical Abacus,An abacus with rotating mechanical gears at each bead
+Architectural,Archway Framing,Using architectural arches to frame subjects
+Psychic Impressionism,Subconscious Doodle Orbit,"Freehand doodles circling the scene, representing subconscious wanderings"
+Obscure & Avant-Garde,Honeycomb Polychrome,Interlocked hexagons with shifting rainbow hues
+Experimental,Ice Crystal,Using frost patterns as natural frames
+Architectural,Bridge Structure,Using bridge elements to create frame boundaries
+Architectural,Archway Framing,Using architectural arches to frame subjects
+Fragmented Realities,Shattered Reflection Patch,Small broken mirror patches each reflecting a different scene
+Biomorphic Patterns,Leaf Vein Lattice,A repeating lattice derived from magnified leaf veins
+Strange Anthropomorphism,Candlestick Families,Clusters of candlesticks with child-like silhouettes
+Experimental,Glass Shatter,Using controlled glass breaks as frames
+Embodied Dreams,Torso Landscape Merge,Rolling hills that blend seamlessly into a reclining torso
+Composite,3D Projection,Using projected elements as frames
+Tapestry Style,Fabric Mat Border,Using complementary fabric as frame material
+Print Effects,Overprint,Color overlay interaction effects
+Fragmented Realities,Mirror Slice Overlaps,Segments of mirrored reflections slightly offset
+Silent Cinematic,Torn Celluloid Edges,Film edges burned or torn from old projectors
+Psychological,Anamorphic Extension,Frames that change with viewing angle
+Celtic Revival,La Tène Vines,Curvilinear motifs reminiscent of Iron Age Celtic art hugging the border
+Experimental,Holographic Foil Fringe,Ruffling or tearing holographic foil to catch the light as an eccentric boundary
+Myth-Punk Fusion,Flying Ship Leviathan,An airship’s prow shaped like a leviathan forming a curved border
+Texture Effects,Halftone Pattern,Creating dot patterns for vintage print feel
+Obscure & Avant-Garde,Oscillating Ribbon Edge,Rippling ribbons in constant rhythmic motion along the boundary
+Human Elements,Hair Frame,Using flowing hair as organic frame elements
+Neoplastic Remnants,Modular Geometry,"Shapes that fit together like a puzzle, each in a primary hue"
+Aqueous Vision,Bubble Ring Chain,Successive rings of bubbles looping around the composition
+Eco-Conscious,Foliage Reclamation,Overgrown vines and leaves wrapping the borders in a reclaimed-by-nature look
+Material Fusion,Concrete-Glass Hybrid,Embedding shattered glass in concrete edges for a raw industrial look
+Strange Anthropomorphism,Bicycle Limbs,Bicycles with human limb shapes forming the border
+Wabi-Sabi Aesthetic,Rough Clay Fragment,Broken clay shards carefully arranged around the perimeter
+Cyber Baroque,Chrome Scroll Brackets,Polished metallic brackets shaped into ornate flourishes
+Ancient Algorithm,Sealed Data Cylinder,A cylindrical seal etched with coded references forming the border
+Obscure & Avant-Garde,Kaleidoscope Hive,Geometric honeycomb patterns refracting in multi-hued repetitions
+Retro-Spiritual,Psychedelic Halos,Concentric rings of rainbow light reminiscent of 1970s poster art
+Gritty Noir,Bullet Hole Glass,Shattered bullet holes forming a ring of cracked glass
+Architectural,Window Frame,Utilizing window structures as viewing portals
+Abstract,Broken Polygon Grid,An angular grid where some polygons shift or break to reveal the subject
+Celestial Wonders,Aurora Borealis Arc,Rippling lights shaped into an arc at the top for a cosmic flourish
+Light Play,Binary Light Dots,Small on/off light points arranged systematically near borders
+Mythical Cyberpunk,Cyber Oni Mask,A futuristic demon mask with glowing circuit lines at the top corners
+Folk Art Revival,Floral Embroidery Band,Colorful embroidered flowers running across the edges
+Abstract,Shape Overlay,Using geometric overlays as frames
+Material Fusion,Ice Formation,Temporary frames using frozen water
+Human Elements,Group Circle,Using circular human formations as frames
+Light Play,Firefly Simulation,Pinpoints of flickering lights reminiscent of fireflies around the frame
+Exoplanet Surfaces,Metallic Sand Dunes,Shimmering dunes with metallic flecks under an alien sun
+Retro-Spiritual,Vibrant Star Gate,A star gate motif with 70s gradient stripes leading into the composition
+Vaporwave Essence,Japanese Text Slivers,Random vertical Japanese text strips as a stylized border
+Mythical Cyberpunk,Synthwave Lotus,A neon lotus bloom with grid lines forming an energetic border
+Natural Framing,Foliage Window,Creating viewports through dense vegetation
+Ethereal Ruins,Floating Debris Orbit,Circular swirls of shattered stone blocks looping around
+Natural Effects,Tissue Overlay,Creating translucent textural effects
+Digital Effects,Pixel Sorting,Organized pixel displacement
+8-Bit Style,Score Display Frame,Using point counters as top frame elements
+Negative Shadow,Dark Glass Transparency,Smoked glass shapes that obscure parts of the perimeter
+Human Elements,Eye Reflection,Using eye close-ups as natural frames
+Mandala Worlds,Sunburst Mandala,Radiating lines forming a symmetrical star-like design
+Incandescent Symbolism,Angelic Fire Wing,"Translucent, fiery wings that flutter at opposite corners"
+Composite,Digital Distortion,Using controlled glitch effects as frames
+Architectural,Corridor Frame,Using hallway perspective for natural framing
+Industrial Grunge,Oil Spill Swirls,"Dark, iridescent oil slick patterns leaking from the corners"
+Chromatic Shatter,Shattered Hologram,Splinters of holographic film fraying into rainbow arcs
+Abstract,Overlap Transparency,Translucent shapes layered at partial opacities around the perimeter
+Incandescent Symbolism,Blazing Heraldic Crest,A coat of arms ignited in shimmering flames near the top
+Art Brut Chaos,Crude Clay Lump,Haphazard lumps of clay pressed into corners
+Luminescent Physics,Photon Spray,Bright speckles of light resembling photon bursts near edges
+Random Obscura,Melted Candy Stripes,"Vibrant, melting sugar stripes drooping from all sides"
+Embodied Dreams,Cloud Ears,Soft cloud shapes positioned like big ears listening from corners
+Pastel Macabre,Soft Ghoul Silhouettes,"Gentle, childlike ghoul figures peeking from behind pastel curtains"
+Destructive,Concrete Rubble,Chunks of concrete rubble piled at the bottom or sides
+Magical Realism,Sunken City Silhouette,Faint outlines of buildings submerged below a watery horizon
+Dream Collisions,Star-Feather Quill,Feathers that sparkle with tiny starlight forming top corners
+Obscure & Avant-Garde,Ghost Geometry,"Transparent, multi-layered polygons that flicker in and out"
+Fragmented Realities,Mosaic Phase Shift,Geometric mosaic patterns shifting hue across each tile
+Light Techniques,Underlit Rim,Lighting from below to create a dramatic rim around the perimeter
+Anime Fusion,Kawaii Pastel Frames,"Soft pink and baby-blue clouds of hearts, stars, and sparkles"
+Hippie Psychedelia,Groove Line Bloom,"Wavy lines emanating from corners in vibrant, swirling bursts"
+Obscure & Avant-Garde,Abyss Kiss,A ring of parted lips leading into a black abyss
+Speculative Plastics,Foam Cushion Edge,Corner pieces shaped like packing foam hugging the image
+Color Effects,Ink Wash,Layered ink effects for depth
+Interstellar Dreamscapes,Stardust Spiral,A glittering spiral of cosmic dust that winds around the scene
+Surreal Puppetry,Tangled Thread Maze,A chaotic web of tangled strings overlapping the edges
+Destructive,Paint Splash Border,Using liquid paint as dynamic frame elements
+Digital Effects,Glitch,Controlled digital corruption patterns
+Surreal Horizons,Geometric Dawn Rays,Angular beams of morning light fanning out in precise geometric shapes
+Ancient Algorithm,Labyrinthian Circuit,Maze-like circuit patterns referencing ancient labyrinth designs
+Industrial Grunge,Bolted Metal Patchwork,Sheets of riveted metal plates forming a rough patchwork border
+Human Elements,Hand Frame,Using human hands to create viewing windows
+Zen Minimalism,Mist Gradient Fade,A gentle grayscale haze fading in from the edges
+High-Tech Minimal,Slim Geometric Frames,Precise line shapes forming a geometric cage around the subject
+Celtic Revival,Cross Knot Edges,Four symmetrical crosses with knotted arms at each corner
+Gritty Noir,Cracked Neon Signs,Broken neon tubes flickering in partially spelled words
+Aqueous Vision,Sunken Ship Aperture,A partial silhouette of a broken mast or hull framing the lower edge
+Destructive,Broken Ceramic Shards,Fragments of pottery arranged haphazardly at corners
+Light Play,Smoke Screen Dynamic,Controlled smoke as ethereal frame elements
+Obscure & Avant-Garde,Camo Circuit Patterns,Overlapping camouflage and circuit board lines merging at corners
+SteamPunk Gears,Copper Pipe Inlay,Intricate piping weaves around the subject
+Spiral Biomes,Undersea Vortex,A watery spiral with fish and coral shapes weaving from the corners
+Embodied Dreams,Palms Holding Skyline,Hands gently cradling a cityscape near the bottom border
+Natural Framing,Branch Framing,Strategic use of tree branches to create organic borders
+Polyptych,Diptych Mirror,Creating symmetrical two-panel compositions
+Vector Style,Gradient Mesh Frame,Using color gradient networks as frames
+Paleo-Futuristic,Runic Computer Tabs,Engraved runes that also look like futuristic interface icons
+Fragmented Realities,Triple Exposure Gates,Three overlapping doorways from different realities
+Cyber Baroque,AI-Victorian Framework,A fusion of Victorian scrollwork with floating digital data shapes
+Light Techniques,Candlelit Glow,"Placing candles in the foreground for a warm, flickering border"
+Aerial Whimsy,Whirligig Kites,Spinning kite-like shapes with whimsical tails at each corner
+Celestial Decadence,Constellation Jewels,Sparkling gems placed where constellation stars would be
+Obscure & Avant-Garde,Veil of Dragonflies,Dozens of translucent dragonfly wings circling the composition
+Eco-Conscious,Foliage Reclamation,Overgrown vines and leaves wrapping corners as if reclaimed by nature
+Cyber Baroque,Neural Lace Inlay,A labyrinth of neural-circuit patterns woven like lace
+Dreamlike Collisions,Clock-Face Blooms,Flowers with clock faces opening like petals
+Biomorphic Patterns,Veinous Marble Swirls,Marble-like patterns with vein structures reminiscent of natural stone
+Magical Realism,Crystal Suncatcher,Prismatic crystals casting dancing rainbow lights
+Experimental,Mirror Fragments,Using broken mirror pieces as frame elements
+Composite,Mixed Media,Combining different media as frames
+Vector Style,Geometric Breakdown,Deconstructed geometric frame elements
+Silent Cinematic,Projector Light Beam,A single diagonal beam of light shining from a vintage projector
+Random Obscura,Accordion Fold Waves,Concertina paper folds set at intervals around the composition
+Folk Art Revival,Wheat Sheaf Corners,"Dry wheat bundles tied at each corner, symbolizing harvest"
+Light Play,Backlight Halo,Using light sources to create glowing borders
+Obscure & Avant-Garde,Spectral Origami Swans,Folded paper swans overlapping in ghostly multiple exposure
+Magical Realism,Ethereal Ribbon Bound,Semi-transparent ribbons that gently tether elements of the image
+Silent Cinematic,Film Countdown Numbers,Random frames of countdown leader markers near the edges
+Strange Anthropomorphism,Keyhole Mouth Frame,Keyholes that appear to open and close like little mouths
+Natural Effects,Organic Pattern,Using natural materials for texture transfer
+Neo Symbolic,Eyes in Triangles,All-seeing eye motifs repeated in triangular shapes around the perimeter
+Experimental,Liquid Ink Bloom,"Allowing ink to bloom in water around the edges, creating organic shapes"
+Retro-Spiritual,Sunburst Chakra,Radiating lines of color each representing a different chakra
+Destructive,Thread-Tear Method,Strategic threading and controlled tearing
+Natural Effects,Rubbing Texture,Transferring surface textures through rubbing
+Retro-Spiritual,Day-Glo Mandorla,An almond-shaped aura in bold fluorescent hues
+Space Opera,Asteroid Belt Arc,A semicircle of drifting asteroids overhead
+Destructive,Acid Erosion Streaks,Vertical streaks that appear 'melted' by acidic damage
+Print Effects,Ink Spread,Simulated ink absorption into paper
+Experimental,Fabric Flow,Using flowing fabric as dynamic frame elements
+Ancient Algorithm,Fractal Mesoamerican Glyphs,Fractal expansions of glyph-like squares reminiscent of Mayan script
+Neoplastic Remnants,Primary Color Blocks,"Red, yellow, and blue squares forming a strict geometric border"
+Spiral Biomes,Mystical Fire Swirl,Blue and green flames spiraling outward in a magical ring
+Light Techniques,Silhouette Border,Using backlit subjects as frame elements
+Embodied Dreams,Hand Drawn Vistas,Dreamy sceneries literally drawn by giant hands holding pencils
+Color Surreality,Iridescent Smoke Puffs,Billowing pastel smoke with shifting rainbow reflections
+Ancient Algorithm,Sunken Algorithmic Symbols,3D-engraved symbols receding into a marble-like surface
+Zen Minimalism,Stone Garden Lines,Gently raked sand patterns forming parallel ripples around the artwork
+Color Effects,Color Bleeding,Intentional ink or paint bleeding
+Pastel Macabre,Melting Candle Drip,Wax drips in baby pink and lavender forming a soft perimeter
+Fragmented Realities,Shifting Puzzle Plane,A puzzle with drifting pieces revealing alternate dimensions
+Tech-Decay Chic,Flickering Neon Skeleton,A half-broken neon sign outline flickers as the frame
+Random Obscura,Marble Run Maze,Miniature labyrinth channels as if a marble could roll around the border
+Abstract,Line Movement,Using dynamic lines as frame elements
+Paper Texture,Ingres,Distinctive linear pattern ideal for soft pastels
+Strange Anthropomorphism,Bottle Neck Chorus,Bottle shapes lined up as though singing along the top
+Experimental Expression,Translucent Shadow Casting,"Stencils that cast layered, shifting shadows onto the frame"
+Pastel Macabre,Floral Scythe Outline,A whimsical scythe shape adorned with pastel blooms along the edges
+Industrial Grunge,Heavy Machinery Parts,"Gears, pistons, and industrial scraps arranged around the perimeter"
+Light Play,Mirror Fragment,Broken mirror pieces as reflective frame elements
+Material Fusion,Magnetic Field,Using ferrofluid for dynamic borders
+Interstellar Dreamscapes,Dark Matter Flow,"A swirling, black, ink-like substance with flecks of starlight"
+Fractal Universe,Cantor Step Edge,Blocky stepping fractals that recede at each iteration
+Pastel Macabre,Doll Eye Buttons,Oversized button eyes in pastel colors scattered around
+Luminescent Physics,Laser Beam Weave,Interlaced laser lines forming a luminous weave at the margins
+Pastel Macabre,Cupcake Tombstones,Tiny tombstones decorated like frosted cupcakes nestled in the corners
+Negative Shadow,Haunted Flicker Border,Pulsating edges as if a light source flickers behind a silhouette
+Psychic Impressionism,Translucent Thought Bubbles,Faint spheres that hint at intangible ideas floating at the edges
+Cyber Tribal,Glowstick Skeleton,Bright neon outlines in a skeletal tribal design
+Space Opera,Hyperdrive Portal,Spiral of star-like streaks forming a jump gate at the center top
+Anthropomorphic Auras,Faces in the Margin,Subtle silhouettes of human faces gazing inward from the perimeter
+Light Techniques,Silhouette Border,Using backlit subjects as frame elements
+Experimental Expression,Welded Scrap Curves,Sculptural lumps of welded metal twisting in arcs
+Hippie Psychedelia,Beaded Curtain Edge,"Dangling beaded strands on either side, parted to reveal the center"
+Dystopian Retro,Barbed Wire Halo,Sharp barbs forming a twisted circular crown
+Organic Sci-Fi,Gene Strand Vines,Twirling vines shaped like twisted DNA sequences
+Light Play,Fiber Optic Edge,Light-conducting materials as frame borders
+Hippie Psychedelia,Spiral Tapestry,Hypnotic swirl reminiscent of 1960s poster art
+Dystopian Retro,Propaganda Poster Peel,Layers of torn propaganda posters revealing the image within
+Artistic Effects,Torn Edge,Organic ripped paper effects
+Destructive,Eroded Material,Deliberately weathered or corroded frame materials
+Mythical Cyberpunk,Dragon Neon Spine,A blazing neon dragon spine snaking along the perimeter
+Tech-Decay Chic,Overgrown Machine,Mechanical gears entangled with vines and moss around the perimeter
+Vector Style,Isometric Frame,Using isometric perspective for frame design
+Natural Framing,Volcanic Rock Window,Finding natural holes in cooled lava formations for a dramatic enclosure
+Gritty Noir,Newspaper Headline Scraps,Torn clippings from sensational headlines arranged along the edge
+Industrial Grunge,Steel Mesh Overlay,A chain mesh pattern layered semi-transparently over the composition
+Material Fusion,Wooden Resin River,Wood slabs with a 'river' of resin flowing between them as a frame
+Natural Framing,Tunnel Vision,Using natural archways or openings to frame subject
+Light Techniques,Lens Flare Frame,Using controlled lens flare as frame elements
+Obscure & Avant-Garde,Data Tapestry,Woven binary threads forming a digital-meets-textile border
+Modern Kitsch,Neon Pineapple,"Bright tropical fruit repeated in an ironic, playful way"
+Magical Realism,Living Book Pages,Pages flipping outward forming a literary vortex around the edges
+Twisted Cartography,Variable Scale Zones,Sections of map magnified or minimized in unexpected ways
+Polyptych,Ascending Panels,Graduated size increase across panels
+Twisted Cartography,Compass Needle Orbit,Multiple needle tips rotating around the center in elliptical paths
+Ancient Algorithm,Code Wheel Edges,Multiple rotating wheels inscribed with lines of code at corners
+Light Play,Cyber Glow Accents,Small neon lines or bars placed at intervals to produce a futuristic glow
+High-Tech Minimal,Negative Space Icons,Simple tech icons arranged with wide spacing around the boundary
+Ethereal Ruins,Phantom Stair Particles,Steps turning into dust motes that vanish mid-step
+Tactile Sensations,Feather Soft Fringe,Delicate feathers forming a pillowy margin
+Mythical Cyberpunk,Ancient Code Mandala,A circular mandala made of cryptic runes and binary code
+Dreamlike Collisions,Suspended Mirror Spheres,Mirrored orbs reflecting surreal landscapes at corners
+Composite,Mixed Media,Combining different media as frames
+Tapestry Style,Floating Display,Minimalist suspension framing technique
+Obscure & Avant-Garde,Static Mycelium,Fungal threads that pulse with tiny static flickers
+Surreal Horizons,Reflective Sunset Arch,An arch made of mirrored sunset colors that loops over the focal point
+Dreamlike Collisions,Feathered Spiral Conch,A conch shell morphing into colorful feathers around the edges
+Human Elements,Hand Frame,Using human hands to create viewing windows
+Light Play,Emergency Beacon Pulse,"Intermittent flashes like a beacon, lighting the edges in short bursts"
+Obscure & Avant-Garde,Glass Lace Filigree,Spiderweb-fine glass strands forming delicate loops
+Vector Style,Low Poly Frame,Using geometric polygonal shapes as borders
+Architectural,Pillar Shadows,Employing the long shadows of pillars to outline the subject
+Spiral Biomes,Forest Whirlpool,A radial swirl of tree silhouettes that spin around the subject
+Print Effects,Paper Grain,Textural surface noise
+Abstract,Texture Contrast,Using textural differences as frames
+Experimental Expression,Hazard Tape Collage,Bright caution tapes crisscrossing in chaotic geometry
+Light Play,Backlight Halo,Using light sources to create glowing borders
+Destructive,Thread-Tear Method,Strategic threading and controlled tearing
+Psychic Impressionism,Intuitive Swirls,Spontaneous swirling lines that respond to emotional undercurrents
+Color Surreality,Chromatic Pulse Lines,Vibrating lines that cycle through the color spectrum
+Arcane Runes,Lunar Rune Phase,Rune sequences matching moon phases placed along the border
+8-Bit Style,Sprite Sheet Grid,Arranging images in classic sprite sheet format
+Obscure & Avant-Garde,Neo-Cubist Cracks,"Fragmented, angled lines paying homage to cubism’s multiple viewpoints"
+Zen Minimalism,Empty White Space,"An expansive white margin, focusing attention on the center"
+Texture Effects,Screen Print,Tactile overlapping layers with slight misalignment
+Obscure & Avant-Garde,Entropic Petri Dish,"Cell-like shapes in chaotic growth, overlapping at the edges"
+Material Fusion,Tar & Feather Fusion,An odd combination of sticky black tar and feathers at the edges
+Arcane Runes,Transmutation Symbols,Complex diagrams from esoteric texts aligned at the edges
+Composite,Digital Distortion,Using controlled glitch effects as frames
+Myth-Punk Fusion,Steam Siren Whirls,Spirals of steam swirling like a siren’s call at the edges
+Surreal Puppetry,Puppet Stage Curtains,Small theatrical curtains opening at the top corners
+Anime Fusion,Chibi Character Crowd,Tiny cartoon figures reacting excitedly around the edges
+Sculptural,Material Transition,Frames that blend into artwork
+Surreal Puppetry,Shadow Puppet Silhouettes,Sharp silhouettes of hands forming animal shapes
+Material Fusion,Marble Fracture Fill,Cracks in marble filled with contrasting material for decorative effect
+High-Tech Minimal,Holographic Grid,"A light, ghostly grid that rotates with perspective"
+Human Elements,Embrace Outline,"Two people embracing in silhouette, forming a heart-like border"
+Experimental,Aluminum Transfer,Metallic texture effects using foil
+Neo-Shamanic,Bone Totem Collage,Stitched-together animal bones forming a towering totem along the border
+Dream Collisions,Cotton Candy Mountain,Fluffy pink mountains reminiscent of sugary confections
+Destructive,Corroded Metal Overlay,Pieces of rusted metal flaking away at the corners
+Esoteric Botany,Lunar Blossom Cycle,Flowers changing shape as if guided by moon phases around the perimeter
+Embodied Dreams,Living Hair Waves,Giant waves shaped like tresses of hair lapping at the edges
+Obscure & Avant-Garde,Opalescent Ectoplasm,Swirling pastel fog with an otherworldly luminescence
+Subterranean Myths,Dripping Vine Roots,"Thick, gnarled roots weaving down from the top corners"
+Ethereal Ruins,Floating Column Segments,Broken columns suspended in mid-air around the scene
+Subterranean Myths,Tunnel of Gargoyles,Stone gargoyle faces peering from curved subterranean walls
+Architectural,Balcony View,Using balcony elements to frame landscapes
+Surface Effects,Synthetic Smooth,Non-porous surface for mixed media
+Architectural,Corridor Frame,Using hallway perspective for natural framing
+Abstract,Streaked Gradient,"Sweeping, brush-like gradient streaks that fade into the focal area"
+Surreal Horizons,Surreal Skyline Stretch,City skyline elongated vertically to form a draped curtain along the edges
+Obscure & Avant-Garde,Glass Clock Gears,Transparent clockwork layered so internal gears are visible
+Architectural,Stairway Leading,Using staircase architecture as frame elements
+Random Obscura,Polka Dot Ectoplasm,Transparent polka dots floating like ghostly slime around the edges
+Human Elements,Multiple Hands Vignette,Several hands reaching inward from all sides in a unifying motif
+Folk Art Revival,Story Quilt Narrative,Miniature scenes stitched like a folktale around the central image
+8-Bit Style,Console Window,Framing within classic gaming console windows
+Embodied Dreams,Oneiric Window Gaze,A window with a giant blinking eye peering inward
+Surface Effects,Embossed Canvas,Pressed canvas-like texture for oils and acrylics
+Negative Shadow,Reversed Light Beam,Bright beam in the center fading to darkness at edges
+Mystical Folklore,Floating Rune Stones,Hovering stones etched with ancient symbols scattered around corners
+Surface Effects,Sanded Coating,Gritty abrasive surface for multiple pastel layers
+Paper Texture,Cold Press,Natural-looking texture created with woolen felts
+Fragmented Realities,Colliding Panel Edges,Panels from diverging scenes compressed at the borders
+Psychological,Infinite Regression,Recursive frame-within-frame patterns
+Natural Framing,Vine Drapes,Letting vines hang overhead to form a natural curtain around the composition
+Tapestry Style,Shadow Box Float,Creating depth between glass and textile
+Light Techniques,Moonbeam Aperture,Using moonlight through a small opening to naturally spotlight the subject
+Cyber Baroque,Glitched Rococo,Rococo flourishes that occasionally break into pixelated errors
+Destructive,Eroded Material,Deliberately weathered or corroded frame materials
+Neo Symbolic,Geometric Zodiac Ring,Twelve zodiac emblems spaced evenly in a symmetrical ring
+Biomorphic Patterns,Feathered Plume Rise,Delicate feather plumes rising from the bottom corners
+Light Play,Prismatic Lens Spots,Using a beveled lens or prism to create diffused light spots
+Architectural,Balustrade Overlook,Using railings to create layered foreground frames
+Folk Art Revival,Batik Dye Pattern,"Bright, wax-resist dyed patterns swirling at the edges"
+Incandescent Symbolism,Phoenix Feathers Embers,Scattered fiery feathers fading into embers
+Esoteric Botany,Spiky Biotech Seeds,"Sharp, futuristic seed pods with metallic finishes"
+Cyber Tribal,Digital Earth Carving,Electronic lines etched as though carved from stone
+Celestial Decadence,Sun-Flare Baroque,Flamboyant sun rays with ornate swirling edges
+Retro-Spiritual,Hazy Dharma Wheel,A softly glowing wheel with gentle rainbow edges
+Obscure & Avant-Garde,Fossil Spiral,A spiral border reminiscent of fossilized ammonites
+Artistic Effects,Collage,Mixed media layered composition
+Obscure & Avant-Garde,Cathedral Spire Shards,"Pointed, stained-glass spires overlapping to create a prismatic arch"
+Urban Street Graffiti,Subway Scrawl,Graffiti reminiscent of train car scribbles forming dynamic side frames
+Paleo-Futuristic,Cyber Raptor Claw,Robotic dino claws gripping corners with neon highlights
+Surreal Horizons,Double Horizon Effect,Two parallel horizon lines framing the subject from above and below
+Composite,Infinite Reflection Nest,Layering a repeated reflection of the same image to create fractal frames
+Obscure & Avant-Garde,Chitin Carapace,Insect-like shell plates building up around the frame
+Composite,Photo Mosaic,Using tiny images as frame elements
+Organic Sci-Fi,Helix Lace Pattern,Delicate lattices repeating the double-helix form in multiple rings
+Industrial Grunge,Cracked Asphalt Lines,Fissures in the ground radiating from the corners
+Polyptych,Interlocking Panels,Panels that share connecting elements
+Celestial Wonders,Lunar Eclipse Overlay,A partial eclipse silhouette placed for dramatic effect
+Anime Fusion,Storyboard Sketch Lines,Rough storyboard frames half-drawn at the margins
+Neo-Shamanic,Shaman’s Dream Catch,"Web-like patterns drifting across the perimeter, capturing ephemeral shapes"
+Tapestry Style,Medieval Border,Historical manuscript-style borders
+Obscure & Avant-Garde,Vortex Collage,Multilayered swirl of images suggesting a dimensional collage
+Light Techniques,Reflection Frame,Using water reflections as bottom frames
+Composite,3D Projection,Using projected elements as frames
+Psychic Impressionism,Color Aura Halo,Colorful aura rings blossoming outward from the center
+Human Elements,Hair Frame,Using flowing hair as organic frame elements
+Abstract,Color Block Frame,Using solid color elements as borders
+Myth-Punk Fusion,Mechanical Kraken Arms,"Tentacles made of segmented metal, wrapping the edges"
+Anthropomorphic Auras,Hands of Many,Dozens of hands forming a shape around the subject
+Destructive,Shattered Glass Integration,Strategic breaking of glass as frame element
+Hippie Psychedelia,Cartoonish Sunshine Rays,"Bright, stylized sunbeams framing the top in a whimsical style"
+Obscure & Avant-Garde,Binary Code Blossoms,Flower heads made of 1s and 0s in swirling arrays
+Human Elements,Barefoot Circle,"Feet arranged in a circle, toes pointing inward for a whimsical bottom frame"
+Luminescent Physics,Atomic Glow Points,Tiny orbs glowing like electron orbits scattered around
+Destructive,Chemical Etch Marks,Acidic or chemical processes leaving random etched lines
+Esoteric Botany,Bio-Luminescent Petals,Dark environment with faintly glowing flowers framing the scene
+Biomorphic Patterns,Spiral Shell Aperture,The swirling geometry of a seashell framing the subject
+Mythical Cyberpunk,Samurai Circuit Armor,Intricate plating with luminous lines forming a partial silhouette
+Experimental,Crystal Refraction,Using crystal elements for prismatic framing
+Surreal Puppetry,Paper Doll Chain,Linked paper dolls stretched across the perimeter
+Composite,Hologram Patchwork,Different segments of holographic imagery stitched together at the edges
+Light Techniques,Bright Overexpose Fade,Overexposing the borders slightly so the subject emerges from glowing white edges
+Arcane Runes,Pentagram Flares,Slight star-shaped flares echoing an arcane pentagram
+Composite,Time Slice,Using multiple time frames as borders
+Vector Style,Mathematical Grid,Using vector grid systems as frame structure
+Surreal Horizons,Rippled Horizon Warp,"A wave-like distortion across the horizon, as though seen through moving water"
+Experimental,Salt Technique,Crystalline effects using salt on wet media
+Natural Framing,Coral Reef Aperture,Employing gaps in coral reefs as underwater 'windows' to highlight a subject
+Eco-Conscious,Recycled Paper Collage,A patchwork of repurposed paper scraps forming a rustic edge
+Natural Framing,Fallen Log View,Positioning the camera through a hollow trunk or fallen log for a rustic frame
+Natural Framing,Mountain Pass,Using valley walls as natural vertical frames
+8-Bit Style,Scanline Overlay,Adding CRT-style scanlines as frame elements
+Speculative Biotech,Hybrid Flora Vessels,Organ-like plant pods acting as an organic technological frame
+Chromatic Shatter,Prism Debris,Broken shards of rainbow-colored glass scattering outward
+Folk Art Revival,Decorative Matryoshka,Nested doll shapes repeated along the perimeter
+Cyber Tribal,Tribal Binary Tattoos,Bold lines of binary code shaped into tribal markings
+Light Play,Mirror Fragment,Broken mirror pieces as reflective frame elements
+Ethereal Ruins,Cracked Angel Frieze,Stone angels with chipped wings arrayed in an incomplete row
+Neo Symbolic,Liquid Ouroboros,"A serpent biting its tail, made of swirling liquid, encircling the image"
+Ethereal Ruins,Ghostly Arch Remnants,Parts of an ancient arch fading in and out at the edges
+Obscure & Avant-Garde,Sand Pendulum Lines,"Curving lines drawn by an imaginary pendulum, crossing corners in loops"
+Myth-Punk Fusion,Steam-Powered Centaur,"Half gear-laden machine, half horse figure silhouette"
+Ceremonial,Incense Smoke Veil,A drifting haze of incense smoke forming a soft ephemeral border
+Destructive,Shattered Glass Integration,Strategic breaking of glass as frame element
+Composite,Photo Mosaic,Using tiny images as frame elements
+Esoteric Botany,Mandrake Silhouette,Plant shapes with hidden human-like roots lurking near corners
+Abstract,Offset Spiral Lines,Overlapping curved lines offset from the center for a vortex-like border
+8-Bit Style,Health Bar Frame,Using game HUD elements as decorative borders
+Aqueous Vision,Reflective Wave Arc,A curling wave crest forming a perfect overhead arc
+Obscure & Avant-Garde,Babylonian Glyph Wave,Ancient cuneiform symbols rolling in wave-like patterns across the border
+Painted Illusions,Spilled Ink Border,Freeform ink shapes seeping into the scene like an unfolding illustration
+SteamPunk Gears,Clockwork Rose Frame,Metallic roses entwined with cogs and clock hands forming a wreath
+Destructive,Paint Splash Border,Using liquid paint as dynamic frame elements
+Magical Realism,Feathered Rain,Soft feathers falling like raindrops from the corners
+Obscure & Avant-Garde,Pleated Paper Façade,Sharp origami folds with architectural flair
+Neoplastic Remnants,Plastic Overlapped Grids,Multiple translucent grids layered in primary colors
+Composite,Double Exposure,Using overlaid images as frame elements
+Obscure & Avant-Garde,Chromatic Brain Fissure,"Psychedelic crack lines reminiscent of neural pathways, bursting with color"
+Biomorphic Patterns,Cell Division Fringe,Abstract shapes reminiscent of cells splitting along the edges
+Human Elements,Gesture Frame,Using body gestures to create frames
+Art Brut Chaos,Childlike Monster Doodles,Primitive doodles of friendly monsters scribbled in bright crayons
+Gritty Noir,Detective Badge Emblem,Flickering police badges repeated at each corner in a subdued pattern
+Cyber Baroque,Digital Baroque Swirls,Exaggerated ornamental curls made of circuit lines and neon filigree
+Pastel Macabre,Cotton Candy Skull,"A skull rendered in soft pinks and blues, smiling from the edge"
+Speculative Plastics,Recycled Bottle Mosaic,Bits of flattened plastic bottles forming a quilt-like edge
+Twisted Cartography,Floating Island Shards,Broken pieces of landmasses drifting across the corners
+Polyptych,Polyptych Cascade,Staggered multi-panel arrangement
+Vector Style,Vector Pattern Border,Repeating vector elements as frame borders
+Micro-Macro Fusion,Atom Orbit Lines,Thin orbital paths around the subject mimicking electron movement
+Material Fusion,Bamboo and Paper Blend,Thin bamboo segments integrated with translucent rice paper
+Neo Symbolic,Sacred Heart Circuits,Hearts with circuit paths forming a radiant frame
+Architectural,Fortress Gate View,Positioning the subject through an old fortress gate
+Surreal Horizons,Inverted Ocean Border,"The sea appears at the top of the frame, sky at the bottom, flipping reality"
+Celtic Revival,Triple Spiral Gateway,Central swirling triple spiral forming an arch at the top
+Neoplastic Remnants,Minimal Circle Intersection,One or two circles crossing lines for a simplified boundary
+Abstract,Split-Tone Edges,"Half of the border in one color or tone, the other half in a contrasting palette"
+Mystical Folklore,Foxfire Glow,Ghostly green-blue flames dancing at the margins
+Vaporwave Essence,Statue Bust Overlays,"Classical busts tinted in neon, floating in the corners"
+Ceremonial,Totem Pillars,Vertical pillars adorned with symbolic carvings or patterns flanking the composition
+Obscure & Avant-Garde,Bent Light Prism,A ring of refracted beams that appear physically curved
+Architectural,Modern Overhang Edge,Exploiting a protruding modern architectural overhang as a compositional frame
+Negative Shadow,Dim Reflection Echo,Faint echo of the artwork itself repeated in shadow form
+Subterranean Myths,Subterranean Lake Mirror,"A dark, mirror-like water surface reflecting the main subject"
+Composite,Multiple Exposure Silhouettes,Silhouettes overlaid with entirely different scenes or textures
+Natural Framing,Cloud Formation,Using cloud patterns as natural top frames
+Art Brut Chaos,Scorched Scribbles,Burned edges with charcoal-like scribbles bleeding inward
+Vaporwave Essence,Minimal VHS Distort,Soft glitch lines evoking a worn VHS aesthetic at the edges
+Senses Amplified,Breath Cloud Aperture,"Soft, fog-like puffs resembling exhaled breath forming the margin"
+Composite,High-Low Poly Merge,"One half of the border rendered in a high-res style, the other in low-poly geometry"
+Dream Collisions,Book-Tree Sprout,Books growing from branches like fruit at the perimeter
+Neoplastic Remnants,Color Field Slivers,Thin strips of color fields edging in from the perimeter
+Abstract,Negative Space,Using absence as frame elements
+Neo Symbolic,Sun-Moon Dual Frame,Opposing sun and moon icons anchoring opposite corners
+Retro-Spiritual,Pulsing Paisley Vortex,Paisley shapes throbbing outward in a gentle spiral from each corner
+Composite,Layer Blend,Using blended layers as frame elements
+Obscure & Avant-Garde,Negative Feedback Loops,Self-referential glitch waves swirling in fractal patterns
+Incandescent Symbolism,Blinding Light Rays,Overexposed beams radiating outward as an act of symbolic emphasis
+Pastel Macabre,Marshmallow Bones,"Pale, pillowy bones lined up in a repeated pattern"
+Art Brut Chaos,Frenetic Marker Lines,Overlapping wild lines drawn in permanent marker
+Zen Minimalism,Breath of Air Gap,White space that gently ‘breathes’ around the central element
+Paleo-Futuristic,Flint and Plasma,Glowing plasma rods used with flint-like shards forming the border
+Obscure & Avant-Garde,Fungal Crown,An ornate “crown” of mushrooms that arcs over the top edge
+Obscure & Avant-Garde,Quantum Rose Maze,Roses formed by fractal petals glimmering in ephemeral quantum states
+Light Play,Disco Ball Sparkles,Tiny reflected spots of light moving around the edges
+Experimental,Bubble Wrap Print,Creating textural patterns using bubble wrap
+Biomorphic Patterns,Fish Scale Cascade,Overlapping scale shapes shimmering across the border
+Esoteric Botany,Seed of Life Blooms,Overlapping circles forming floral geometry
+Anime Fusion,Kanji Energies,Electrified Japanese characters glowing along the border
+Random Obscura,Giant Spoon Handles,Elongated spoons arching in from each corner for a surreal effect
+Organic Sci-Fi,Synthetic Coral Growth,Coral structures with LED illumination weaving the perimeter
+Retro-Spiritual,Prismatic Om Wave,The Om symbol repeated in a wave-like arrangement with prismatic shading
+Light Techniques,Soft Lamp Vignette,Utilizing a single lamp’s glow to form a gentle halo around the subject
+Luminescent Physics,Electromagnetic Vortex,A swirling field reminiscent of magnetic lines around the subject
+Dystopian Retro,Metal Shutter Slits,Rusted security shutters cracked to reveal the subject
+Paleo-Futuristic,Tribal Mech Totem,A mechanical totem pole encrusted with shells and archaic designs
+Celestial Decadence,Moon Phase Strings,Graceful arcs connecting multiple moon phases along the margin
+Art Brut Chaos,Scrawled Emotions,"Impulsive, anxious lines twisting along the edges"
+High-Tech Minimal,Line Art CPU,An outline of a microchip design repeated at corners
+Obscure & Avant-Garde,Chandelier Web,A web of delicate crystal beads shimmering in spider-silk arrangements
+Experimental,Detergent Spread,Using soap solutions for organic patterns
+Exoplanet Surfaces,Cracked Lava Plains,"Volcanic, otherworldly cracks radiating from corners"
+Human Elements,Gesture Frame,Using body gestures to create frames
+Architectural,Urban Canyon,Using tall buildings as vertical frame elements
+Esoteric Botany,Glass Terrarium Edge,"Delicate glass structures holding rare, mystical plants"
+Micro-Macro Fusion,Cellular Webwork,Organic mesh reminiscent of micro-cellular structures forming an intricate boundary
+Light Techniques,Bokeh Border,Using out-of-focus lights as frame elements
+Celtic Revival,Shamrock Interlace,Three-leaf motifs woven intricately in a repeated pattern
+Light Play,Rim Light Contrasts,High-contrast lighting along the subject’s edges for a dramatic look
+Natural Framing,Driftwood Archway,Arranging driftwood pieces on a beach to form a makeshift arch
+Industrial Grunge,Concrete Chunk Edges,"Large, broken fragments of concrete forming rugged edges"
+Obscure & Avant-Garde,Pyrography Edge,Wood-burned designs that appear charred into the frame
+Abstract,Fractal Ink Spills,Chaotic inkblot expansions at the corners forming an abstract mosaic
+Natural Effects,Layered Materials,Building depth with multiple material layers
+Dream Collisions,Liquid Glass Drizzle,Glasslike droplets streaming in liquid form from corners
+Folk Art Revival,Patchwork Quilt Margin,Vibrant patterned quilt squares forming a homespun border
+Neo-Shamanic,Ethereal Antler Frame,Delicate horns that branch off into wisps of color and fading lines
+Dreamlike Collisions,Pastel Bubble Arch,A rainbow of soap bubbles forming a dreamy overhead arch
+Eco-Conscious,Carbon-Neutral Border,Minimal line art referencing renewable energy icons as a subtle edge
+Tapestry Style,Woven Edge,Incorporating weaving patterns into frame
+Incandescent Symbolism,Volcanic Crescent,A crescent shape emitting smoke and a molten glow
+Luminescent Physics,Wave-Particle Lines,A swirl of lines that shift from sine waves to dotted particle sequences
+Retro-Futurism,Atomic Age Icons,Boomerang shapes and starbursts repeated along the perimeter
+Dream Collisions,Plant-Animal Hybrid,Leaves morphing into feathers or fur around the frame
+Aqueous Vision,Coral Mirror Portal,Mirrored coral reefs reflecting each other across the borders
+Cyber Tribal,Tribal Tech Portal,Portal ring of geometric shapes bridging primal and futuristic motifs
+Natural Framing,Rock Formation Frame,Using natural rock formations to create boundaries
+Light Techniques,Sunset Silhouette,Using sunset glow as natural frame
+Dream Collisions,Teacup Ocean Rim,A wave crest shaped like a giant teacup handle
+Neo Symbolic,Contrasting Faith Icons,Overlapping spiritual symbols from multiple cultures forming unity
+Obscure & Avant-Garde,Plexus Veil,Interlacing lines reminiscent of muscle fiber or digital wireframes
+Retro-Futurism,Tape Cassette Fringe,Classic cassette tape outlines repeated along the edges
+Exoplanet Surfaces,Gas Giant Bands,Horizontal swirling bands referencing Jovian clouds
+Obscure & Avant-Garde,Photon Entanglement Rays,"Intersecting beams that shift in color, implying quantum linking"
+Experimental,Smoke Screen,Using controlled smoke as dynamic frames
+Mystical Folklore,Tengu Mask Fringe,Repeating mask motifs of mythical Tengu creatures around the border
+Human Elements,Expressive Glove Frame,Using decorative or theatrical gloves posed to outline the subject
+Aqueous Vision,Hydro Thermal Vent,"Dark, twisting columns of hot water vapor curling upward"
+Neo Symbolic,Alchemy Compass,A multi-directional emblem showing elemental icons at the cardinal points
+Surreal Puppetry,Thread Marionette Edge,Delicate puppet strings from the top corners leading to invisible hands
+Cyber Baroque,Metal Fleur-de-lis,Fleur-de-lis motifs polished in steel and gold forming repeated emblems
+Biomorphic Patterns,Reptile Skin Gradient,A subtle gradient of scaly textures transitioning outward
+Senses Amplified,Touch Tactile Frame,A “soft” visual suggestion of felt or velvet to evoke tactile warmth
+Painted Illusions,Canvas Peeling,The subject appears beneath a peeling canvas corner
+Natural Framing,Sand Dune Lines,Using desert formations as natural leading lines
+Obscure & Avant-Garde,Neon Opera Curtain,A stylized stage curtain in neon outlines parting at the center
+Gritty Noir,Streetlamp Halo,Overhead streetlamp cones at the corners casting a moody glow
+Hippie Psychedelia,Liquid Lava Lamp,Globular shapes morphing at the perimeter like a lava lamp effect
+Mystical Folklore,Ice Elf Filigree,"Delicate ice-like patterns etched around the border, evoking elven craft"
+Art Brut Chaos,Random Word Cutouts,Torn newspaper words scattered at random angles
+Aerial Whimsy,Dandelion Seed Drift,Delicate seeds floating across in gentle arcs
+Composite,Layer Blend,Using blended layers as frame elements
+Strange Anthropomorphism,Enchanted Shoe Cluster,"Shoes with slight facial features, dancing around the edges"
+Speculative Biotech,Spliced DNA Strands,Helix shapes spliced with mechanical parts twisting around the edges
+Cyber Baroque,Ornamental Robo Cherubs,Mechanical cherub figures perched at corners
+Folk Art Revival,Hand-Carved Totem Poles,"Tall wooden totems at the sides, etched with traditional folk symbols"
+Destructive,Peeling Plaster,Sections of plaster or paint peeling off in large flakes around the subject
+Aerial Whimsy,Hot Air Balloon Arc,"A series of balloons drifting upward, forming an arch at the top"
+Abstract,Pattern Break,Using pattern interruption as frames
+Dream Collisions,Bubble Skyline,City silhouettes made entirely of floating soap bubbles
+Obscure & Avant-Garde,Mutated Cityscape,Towering building silhouettes that morph into organic shapes near the edges
+Pastel Macabre,Silken Spiderweb Lace,Delicate pastel webs stretching across corners
+Light Techniques,Shadow Cast Frame,Using projected shadows as frame elements
+Industrial Grunge,Factory Vent Smoke,"Billowing, dark smoke plumes framing the edges like a looming factory environment"
+Aerial Whimsy,Cloud Puff Horizon,Soft clusters of clouds forming a boundary just below the subject
+Architectural,Window Frame,Utilizing window structures as viewing portals
+Experimental Expression,Thrown Clay Splatter,"Chunks of clay flung outward, leaving partial shapes near the border"
+Mythical Cyberpunk,Techno-Fan Blades,Repetitive fan shapes with mechanical pivot points
+Light Play,Star Projector Scatter,Projecting star patterns that rotate or move across the corners
+Organic Sci-Fi,Neuron Glow Paths,Fluorescent neuron-like lines branching outward
+Color Surreality,DayGlo Vine Tangle,Intensely bright vines weaving in tangled knots
+Celestial Decadence,Lunar Diamond Edge,Diamond shapes around a silver moon crest repeating at corners
+Modern Kitsch,Lipstick Kiss Marks,Multiple lipstick prints forming a flamboyant border
+Dream Collisions,Toy Block Ruins,Towering ruins built from colorful children's blocks
+Urban Street Graffiti,Brick Wall Cutout,A jagged aperture in a brick wall revealing the central subject
+Experimental,Thread Cross,Using suspended threads for subtle framing
+Tapestry Style,Thread Integration,Incorporating visible stitching as frame
+Senses Amplified,Tasteful Drip,Subtle liquid drips as if honey or syrup is running along the edges
+Celtic Revival,Knotwork Corner Loops,Intricate braided Celtic knots weaving in the four corners
+Strange Anthropomorphism,Potted Plant Eyes,Eyes sprouting on leaves in the corners
+Material Fusion,Living Wall Frame,Incorporating growing plants into frame
+Magical Realism,Translucent Whale Swim,A giant ghostly whale drifting across the sky as a partial border
+Obscure & Avant-Garde,Suspended Fishbowls,Hanging spheres of water with floating fish or plants at the perimeter
+Celtic Revival,Runic Stone Texture,Stone texture inscribed with faint Celtic runes
+Fragmented Realities,Cracked Polaroid Pieces,Photographs fractured into shards around the subject
+Spiral Biomes,Celestial Swirl Terrarium,A swirling miniature habitat contained in glass orbs around the border
+Surreal Horizons,Melting Skyline,"A horizon line that appears to liquify into the sky, creating a soft, dripped boundary"
+Light Techniques,Strobe Light Edges,Pulsing strobe beams on either side to highlight the central figure
+Obscure & Avant-Garde,Blooming Void,An expanding darkness at the edges with glowing floral outlines
+Light Techniques,Bokeh Border,Using out-of-focus lights as frame elements
+Hippie Psychedelia,Floating VW Bus,Tiny silhouettes of a classic van repeated across a psychedelic horizon
+Tactile Sensations,Pebble Mosaic,Smooth stones arranged in a pattern around the frame
+Celestial Wonders,Aurora Borealis Arc,Rippling lights shaped into an arc at the top for a cosmic flourish
+Psychic Impressionism,Lucid Dream Flares,"Bright, hazy blooms of color at the corners, like dream auras"
+Exoplanet Surfaces,Pulsing Bioluminescent Mushrooms,Glowing fungi forming a ring
+Embodied Dreams,Eye Flow Streams,Flowing water that emerges from eyes at the corners
+Abstract,Geometric Pattern,Using repeating shapes as frame elements
+Modern Kitsch,Gingham Picnic Mat,Checkerboard pattern reminiscent of a classic picnic blanket
+Obscure & Avant-Garde,Tessellated Moth Wings,Repeating kaleidoscopic patterns of moth wings at the perimeter
+Natural Framing,Seaweed Window,Using tall strands of seaweed to enclose the subject in flowing silhouettes
+Silent Cinematic,Film Grain Overlay,Noticeable grain effect framing the subject in a retro style
+High-Tech Minimal,Ultralight Beams,Very thin beams of cool white light crisscrossing faintly
+Natural Framing,River Bend Silhouette,Using a natural river bend so its curves frame the focal area
+Human Elements,Holding Object Aperture,Hands holding a circular object (like a ring or hoop) to frame the focal point
+Interstellar Dreamscapes,Zero-G Drips,Floating liquid droplets in microgravity orbiting the central image
+Neoplastic Remnants,Stark White Negative Space,Ample white space with strategic color blocks at corners
+Dreamlike Collisions,Cloud-Bubble Chimeras,"Hybrid shapes part-cloud, part-bubble, forming wispy illusions"
+Print Effects,Edge Distress,Worn and aged edge treatments
+Experimental,Liquid Metals,Capturing swirling mercury-like fluids forming reflective frames
+Destructive,Singe Marks,"Random scorch marks at the corners for a grimy, burnt effect"
+Anthropomorphic Auras,Faces in the Margin,Subtle silhouettes of faces gazing inwards from the corners
+Surreal Puppetry,Disjointed Limbs Border,Floating doll arms and legs arranged in a whimsical puzzle
+Neo-Shamanic,Totemic Feather Shards,Broken feather fragments arranged like jagged tribal icons
+Aerial Whimsy,Lantern Release,Floating lanterns rising from the bottom corners into the sky
+Aqueous Vision,Pearlescent Tide Pools,Irregular shapes shimmering with pearlescent color around corners
+Natural Framing,Cave Aperture,Utilizing cave openings to frame landscapes
+Anime Fusion,Action Line Blast,Dramatic speed lines radiating from the focal area in bright colors
+High-Tech Minimal,Soft Glow Buttons,"Minimal round buttons with a dim, neon glow"
+Urban Street Graffiti,Sticker Slap Collage,A dense patchwork of stickers slapped onto a surface
+Spiral Biomes,Sandstorm Spiral Cyclone,A swirling column of sand drifting across each corner
+Neo-Shamanic,Mask Embers,Glowing embers falling around stylized masks at each corner
+Random Obscura,Psycho-Silhouette Bloom,Inverted outlines of random objects expanding in repeated layers
+Obscure & Avant-Garde,Scattered Tarot Suits,"Hearts, clubs, spades, and diamonds drifting among swirling lines"
+Hippie Psychedelia,Peace Sign Repeat,Multiple retro peace signs drifting through the border
+Negative Shadow,Silhouette Inversion,Reversed silhouette borders that show the subject only in negative space
+Light Techniques,Shadow Cast Frame,Using projected shadows as frame elements
+Obscure & Avant-Garde,Shadow Basilisk Portal,"Dark reptilian silhouettes twisting around the edges, suggesting a hidden labyrinth"
+Experimental,Crystal Refraction,Using crystal elements for prismatic framing
+Digital Effects,Moire Pattern,Interference pattern creation
+Texture Effects,Risograph,Two-tone overlapping ink simulation
+Material Fusion,Cork & Resin Inset,Sections of cork sealed in resin at the margins
+Obscure & Avant-Garde,Liquid Tarot Mirror,Reflective fluid surfaces morphing into vague tarot symbols
+Light Techniques,Spotlight Frame,Using focused light to create natural vignettes
+Celtic Revival,Ogham Script Border,Vertical lines of ancient Ogham text wrapping the frame
+Tactile Sensations,Clay Fingermarks,Finger-impressed clay textures shaping the boundary
+Human Elements,Legs as Columns,Standing figures with legs forming strong vertical edges
+Urban Street Graffiti,Stencil Splash Edges,Spray paint stencils partially covering the border in bold colors
+Fractal Universe,Crystal Fractal Shards,"Sharp, refracting fractal shapes like geometric shards"
+Subterranean Myths,Chthonic Rune Bands,"Ancient, cryptic symbols glowing softly in horizontal bands"
+Light Techniques,Colored Gel Slivers,Adding narrow slices of colored light to the edges for a prismatic effect
+Senses Amplified,Perfume Vapor Edge,Wispy shapes implying fragrant tendrils around the focal region
+Ethereal Ruins,Ancient Doorway Glitch,A half-formed door flickering as though existing between worlds
+Abstract,Texture Border,Using material textures as frame elements
+Obscure & Avant-Garde,Mimicry Mirror,Shapeshifting mirror shards that subtly morph to reflect hidden shapes
+Spiral Biomes,Desert Spiral Crest,A spiral of miniature dunes rising from a single focal corner
+Experimental,Ice Crystal,Using frost patterns as natural frames
+Polyptych,Rotating Panels,Multiple panels with varied orientations
+Experimental,Bubble Frame,Using soap bubbles as ethereal frames
+Micro-Macro Fusion,Quantum Fragments,Tiny fractal shards bridging micro and macro worlds
+Anime Fusion,Sakura Petal Drift,Falling cherry blossom petals drifting in from all corners
+Silent Cinematic,BW Gradient Fade,A black-to-white gradient reminiscent of classic silver screen transitions
+Experimental Expression,Smoke Gel Suspension,A bizarre mixture of colored gel and smoke suspended along corners
+Negative Shadow,Outline Subtraction,"Dark silhouettes carved out, leaving the negative space as the frame"
+Destructive,Burn-Through Edge,Controlled burning patterns in frame material
+Celestial Wonders,Starfield Fade,"Stars getting denser toward the corners, trailing into blackness"
+Color Surreality,Floating Pastel Cubes,Softly tinted cubes lazily drifting in ephemeral patterns
+Neoplastic Remnants,Asymmetric Black Lines,Bold black lines dividing the border into rectangles
+Retro-Spiritual,Checkerboard Nirvana,A black-and-white checker pattern dissolving into a luminous center
+Psychic Impressionism,Pulse Point Brush,Short dashes arranged in rhythmic pulses around the margin
+Material Fusion,Resin Encasement,Small objects embedded within clear resin to form a dimensional border
+Composite,Torn Magazine Layers,Layering torn magazine fragments for a raw collage effect
+Psychic Impressionism,Thought Wave Filament,Fine filaments vibrating as if they carry mental signals
+Modern Kitsch,Polaroid Snapshots,Colorful Polaroid frames pinned haphazardly along edges
+Light Techniques,Rainbow Frame,Using prismatic effects as color frames
+Tapestry Style,Double Matting,Layered mat board creating depth
+Experimental,Clay Smear,"Smearing wet clay around the edges to create earthy, tactile borders"
+Wabi-Sabi Aesthetic,Sun-Bleached Bleed,Subtle overexposure at edges as if faded by years of sunlight
+Light Play,UV Laser Web,Thin UV laser lines crisscrossing as a neon spiderweb
+Vector Style,Sharp Edge Border,Clean vector lines creating frame boundaries
+Psychological,Emotional Response,Frames designed for psychological impact
+Dystopian Retro,Overlapped Nuclear Warnings,Repeating hazard symbols forming the frame
+Light Techniques,Light Beam Frame,Using visible light beams as natural frames
+Architectural,Balcony View,Using balcony elements to frame landscapes
+Destructive,Trashed Collage,Crumpled paper or plastic scraps scuffed and glued around the perimeter
+Celtic Revival,Zoomorphic Knot,Interlacing animal shapes typical of Celtic manuscripts
+Neo-Shamanic,Psychedelic Drum Spiral,A hypnotic circular pattern of tribal drums that appear to spin around the subject
+Light Techniques,Rainbow Frame,Using prismatic effects as color frames
+Abstract,Texture Contrast,Using textural differences as frames
+Obscure & Avant-Garde,Seraphic Stone Carvings,"Angelic silhouettes carved in stone relief, partially crumbling"
+Aerial Whimsy,Blustery Wind Gust,Curving lines representing a playful breeze around the image
+Composite,X-Ray Overlay,Incorporating X-ray imagery or skeleton outlines as a partial border
+Dreamlike Collisions,Feather-Fish Hybrids,Tiny fish with feathered fins swirling around the scene
+Esoteric Botany,Insect-Pollinator Patterns,Repeating silhouettes of bees or butterflies across a floral band
+Neo-Shamanic,Moonlit Ritual Circle,A faint glowing ring of moonlit stones reminiscent of a ceremonial site
+Speculative Biotech,Test Tube Growth,Transparent tubes or fluid-filled vessels with glowing microorganisms
+Aqueous Vision,Kelp Column Silhouette,Long ribbons of kelp rising like pillars at the sides
+Cyber Tribal,Pixelated Animal Masks,Animal totems rendered in low-resolution pixel style
+Color Effects,Paint Splatter,Controlled paint spattering for texture
+Natural Framing,Ice Formation,Using icicles or ice structures as natural frames
+Surreal Puppetry,Mask on Strings,"Hanging masks around the border, each with different expressions"
+Obscure & Avant-Garde,Mechangel Feathers,"Mechanical feathers arrayed in a wide, arching wing at the top corners"
+Vector Style,Node Point Frame,Connected vector nodes creating frame patterns
+Painted Illusions,Window Pane Brushwork,Frame rendered as if behind a realistically painted glass pane
+Destructive,Cracked Clay Edge,Clay or dried mud with deep cracks forming a broken boundary
+Light Techniques,Reflection Frame,Using water reflections as bottom frames
+Space Opera,Plasma Ray Lances,Bright beams of cosmic plasma crossing the border
+Obscure & Avant-Garde,Polaroid Stack,A jumbled pile of Polaroid-style frames layering the border
+Surreal Puppetry,Pinocchio Nose Bridge,Long wooden noses forming diagonal lines at the corners
+Paper Texture,Hot Press,Ultra-smooth surface ideal for detailed work and fine lines
+Obscure & Avant-Garde,Avian Bone Arch,Stylized bird skulls or bones forming a dramatic arch overhead
+Twisted Cartography,Melting Atlas Border,A world map that seems to melt or warp along the edges
+Aqueous Vision,Seafoam Cloud Lace,"Foamy shapes that fade from aqua to white, hugging the edges"
+Obscure & Avant-Garde,Baroque Smoke Swirls,"Lavish, swirling patterns of smoke reminiscent of baroque ornamentation"
+Paper Texture,Rough Press,Heavily textured surface for dramatic effects
+Natural Framing,Tunnel Vision,Using natural archways or openings to frame subject
+Wabi-Sabi Aesthetic,Frayed Linen Edge,"Torn, weathered cloth revealing the subject"
+Material Fusion,Mixed Metal Patchwork,Collage of different metal types welded into a single border
+Obscure & Avant-Garde,Zephyr Petal Drift,"Light, windy flurries of petals that swirl in from the corners"
+Myth-Punk Fusion,Pegasus Wing Gears,Brass gears forming feathery wings on each side
+Speculative Plastics,Translucent PET Window,A faint see-through sheet with a wrinkled texture as a partial overlay
+Obscure & Avant-Garde,Virtual Skyline,Futuristic city silhouettes in neon wireframe at each horizon line
+Speculative Biotech,Nanobot Swarm,Tiny robotic insects or nanites forming a shimmering edge
+Organic Sci-Fi,Translucent Alien Pods,Jelly-like pods glowing with unearthly color at the edges
+Human Elements,Facial Hair Border,Close-up moustaches or beards from different faces forming a comedic upper border
+Mystical Folklore,Shadow Beast Outline,Large mythical beast silhouette partially encircling the center
+Light Techniques,Fire Frame,Using flame or ember effects as dynamic frames
+Natural Framing,Waterfall Curtain,Using falling water as a dynamic frame
+Luminescent Physics,Radiant Particle Curves,Waves of luminous particles curving gracefully across corners
+Experimental,Smoke Screen,Using controlled smoke as dynamic frames
+Obscure & Avant-Garde,Marine Skeleton Reef,Fossil-like corals forming a subaquatic boneyard border
+Architectural,Stairway Leading,Using staircase architecture as frame elements
+Celestial Decadence,Galactic Pearl Strands,"Pearl-like orbs in a chain, each containing a miniature galaxy"
+Experimental,Paint Splash,Using liquid paint as abstract frame elements
+Luminescent Physics,Fluorescent Atom Grid,A faint grid of atoms connected by glowing bonds
+Surreal Horizons,Rising Desert Clouds,Clouds emerging from the sand as if the horizon is inverted
+Natural Effects,Fiber Integration,Incorporating visible paper fibers
+Experimental,Nail Polish Swirl,"Pouring swirling nail polish for a marbled, fluid border"
+Embodied Dreams,Face Merged Forest,Tree trunks forming partial human profiles in the perimeter
+Color Effects,Gradient Map,Converting images to specific color combinations
+Interstellar Dreamscapes,Astral Gate Aperture,A circular portal fringed with twinkling stars
+Experimental,Water Droplet,Using macro water drops as natural lenses
+Aerial Whimsy,Feather Float Parade,Rows of feathers in pastel shades drifting from top corners
+Space Opera,Battle Cruiser Flyby,Tiny ships streaking across corners in formation
+Light Play,Crystal Refraction,Using crystal elements for prismatic framing
+Fractal Universe,Recursive Tunnel,An inward-spiraling fractal that “tunnels” around the subject
+Abstract,Negative Space,Using absence as frame elements
+Interstellar Dreamscapes,Parallel Galaxy Windows,Rectangular portals each revealing a different galaxy
+Color Effects,Duotone,Using two contrasting colors for dramatic impact
+Celestial Decadence,Sapphire Eclipse Frame,"A deep blue ring simulating an eclipse, glowing at the perimeter"
+Strange Anthropomorphism,Fork & Spoon Arms,Utensils bent into playful limb shapes waving in the corners
+Natural Framing,Ice Formation,Using icicles or ice structures as natural frames
+Luminescent Physics,Phase Shift Halo,A subtle halo that shifts color like a refractive phenomenon
+Light Play,Lattice Shadow Overlay,A grid or lattice cast shadow stretching across the corners
+Destructive,Acid Wash,Controlled acid effects for pattern creation
+Obscure & Avant-Garde,Blood Moon Rays,Thin beams tinted a deep red emanating from a lunar orb
+Psychic Impressionism,Telepathic Cloud Form,Mist-like shapes that evoke shared thoughts or hidden messages
+Incandescent Symbolism,Photonic Glyph Pulses,Symbols that pulse in brightness like strobe lights
+Esoteric Botany,Living Vine Script,Cursive lines formed by trailing vines that wrap the corners
+Natural Framing,Branch Framing,Strategic use of tree branches to create organic borders
+Light Techniques,Sunset Silhouette,Using sunset glow as natural frame
+Obscure & Avant-Garde,Inverted Ziggurat,A descending stepped structure that flips perspective at the frame’s edges
+Retro-Spiritual,Astrological Disco,Retro zodiac signs spinning like disco lights around the corners
+Experimental,Powder Explosion,"Using colored powder bursts at the edges for a dynamic, ephemeral frame"
+Natural Framing,Cave Aperture,Utilizing cave openings to frame landscapes
+Material Fusion,Ceramic Tile Mosaic,Colorful ceramic shards fitted together around the frame
+Material Fusion,Clay & Straw Reinforce,An old-world wattle and daub style border with straw peeking through
+Interstellar Dreamscapes,Surreal Comet Arcs,"Multiple comets curving across the edges, leaving glowing trails"
+Senses Amplified,Touch Tactile Frame,A “soft” visual suggestion of felt or velvet to evoke tactile warmth
+Spiral Biomes,Micro Jungle Helix,Tiny vines and leaves forming a delicate spiral structure
+Obscure & Avant-Garde,Ultraviolet Coral Reef,Blacklight-reactive corals pulsing in neon at the borders
+Speculative Plastics,Plastiglomerate Shards,Fused plastic fragments forming a geologic layer around the subject
+Obscure & Avant-Garde,Haunted Puppet Strings,Dangling threads that hint at half-seen marionettes controlling the composition
+Obscure & Avant-Garde,Metallic Insect Mandala,Mechanical insect legs arranged radially in a geometric pattern
+Destructive,Splintered Wood Edges,Rough wooden edges that look freshly broken or splintered
+Tapestry Style,Textile Tension,Using fabric stretching as frame element
+Light Play,Dimmer Fade-In,"Gradually intensifying light at the edges, drawing focus to the center"
+Mystical Folklore,Spiritual Tree Spirits,Faint silhouettes of tree guardians peering from edges
+SteamPunk Gears,Pressure Gauge Corners,Analog dials pinned at each corner
+Light Techniques,Holographic Glint,Positioning hologram reflections so they encircle the main point of focus
+Mythic Realism,Chronicle Script Edge,Ancient rune-like text spiraling around the composition
+Color Surreality,Ombre Glass Panels,Layered glass planes tinted in subtle color transitions
+Experimental Expression,Wire Bent Chaos,Twisted wire forms protruding in random angles at the perimeter
+Surface Effects,Deckled Edge,Natural torn paper edge effect
+Space Opera,Alien Throne Silhouette,A massive throne shape with extraterrestrial design behind the subject
+Anime Fusion,Shōnen Spark Overlays,Jagged shards of explosive energy typical of action anime
+Composite,Double Exposure,Using overlaid images as frame elements
+Neo-Shamanic,Tribal Nebula Aura,A cosmic swirl of tribal paint and soft stardust around the corners
+Ancient Algorithm,Hieroglyphic Data Lines,"Hieroglyphs stacked in logical, data-like sequences"
+Celestial Wonders,Constellation Stitch,Connect-the-dots star patterns forming a cosmic lattice
+Tech-Decay Chic,Corrupted Data Flow,“Melting” code lines drip along the edges in a decaying digital aesthetic
+Experimental Expression,Melted Acrylic Sheets,"Layered, heat-warped acrylic in swirling shapes"
+Random Obscura,Paper Clip Chain,Linked paper clips forming a chain around the edges
+Light Play,Crystal Refraction,Using crystal elements for prismatic framing
+Spiral Biomes,Glacial Spiral Maze,A labyrinth of crystalline ice steps twisting around the perimeter
+Material Fusion,Ice Formation,Temporary frames using frozen water
+Obscure & Avant-Garde,Shadow Gesture Gate,Dramatic silhouettes of hands in expressive poses forming an arch
+Light Play,Shadow Puppet Patterns,Placing cutouts in front of a light source to cast dancing shadows
+High-Tech Minimal,Monochrome Data Stream,Vertical columns of binary fading in and out along the sides
+Architectural,Column Framing,Using vertical columns to create side frames
+Digital Effects,Digital Noise,Controlled grain and artifacts
+Anthropomorphic Auras,Footstep Pattern,Repeating footprints around the perimeter
+Artistic Effects,Cut Paper,Simulated paper cut-out layers
+Interstellar Dreamscapes,Lunar Eclipse Rays,Sharp beams of cosmic light emanating from an eclipse silhouette
+Destructive,Charcoal Smudge,"Dark, smudged charcoal strokes giving a rough break-in feel"
+Obscure & Avant-Garde,Zero Gravity Blossoms,"Flowers seemingly floating upward, ignoring standard orientation"
+Folk Art Revival,Hand-Painted Wooden Planks,Rows of wooden boards bearing folk motifs as a rustic frame
+Gritty Noir,Trenchcoat Figure Outline,A ghostly silhouette of a detective’s coat collar turned up at corners
+Obscure & Avant-Garde,Inkblot Test Portal,Symmetrical inkblot shapes that resemble Rorschach patterns
+Natural Framing,Flowering Shrub Portal,Selecting shrub openings brimming with blooms to spotlight the subject
+Art Brut Chaos,Found Object Paste,Random bits of trash or found objects collaged around the border
+Neo Symbolic,Shield of Chakras,Seven chakra disks arranged in a protective ring
+Speculative Plastics,Shrink-Wrap Silhouette,Tight plastic wrap outlines cling to the corners as if sealed
+Obscure & Avant-Garde,Seaside Glass Cliff,Abstract shards reminiscent of sea glass stacked in a cliff-like shape
+Biomorphic Patterns,Petal Helix,Spiraling flower petals forming a helical border
+Neo Symbolic,Sigil of Rebirth,An abstract phoenix symbol repeated in stylized corners
+Arcane Runes,Ancient Alchemical Circle,Intricate circles dotted with cryptic symbols forming a ritual perimeter
+Abstract,Gradient Frame,Using color gradients as subtle frames
+Tapestry Style,Rustic Barnwood,Weathered wood frame for organic feel
+Ancient Algorithm,Stone Binary,Binary digits chiseled onto stone blocks forming a perimeter
+Zen Minimalism,Paper Screen Silhouette,Subtle shadow squares reminiscent of shōji screens
+Mandala Worlds,Layered Chakras,Nested chakra-like orbs in concentric rings
+Experimental Expression,Ink Lattice Growth,Ink lines that branch out and interweave spontaneously
+8-Bit Style,Character Select Box,Using game UI-style selection boxes as frames
+High-Tech Minimal,Transparent HUD Icons,Faint futuristic interface icons gently framing the center
+Human Elements,Crowd Frame,Using people groups as natural frames
+Ethereal Ruins,Time-Frozen Ivy,"Ivy creeping across ruined walls, locked in a perpetual hush"
+Vaporwave Essence,Grid Horizon Band,Retro 80s neon grid lines forming a central band near the bottom or top
+SteamPunk Gears,Mechanical Wing Span,Extended metal wings with ornate gear joints flanking the sides
+Cyber Tribal,Pulsing LED Warpaint,Glowing lines akin to face paint around the border
+Human Elements,Fingers Crossed Overlay,Layered fingers crossing to form an intricate crisscross border
+High-Tech Minimal,Thin LED Strips,"Subtle, linear LED lights glowing along the perimeter"
+Psychological,Temporal Shift,Time-based frame transformations
+Surreal Puppetry,Marionette Crossbars,Horizontal crossbars with dangling strings framing the subject
+Color Surreality,Neon Ink Pools,"Bright, inky puddles of neon swirling at the corners"
+Retro-Futurism,Wireframe City Loop,A cityscape drawn in wireframe at the lower border curving upward
+Retro-Futurism,Grid Floor Horizon,A Tron-like grid receding into the distance at the bottom
+Composite,Ripped Painting Layers,Simulating torn edges of multiple painted canvases
+Obscure & Avant-Garde,Sandstorm Fade,A gradient of swirling sand particles overtaking the corners
+High-Tech Minimal,Narrow Circuit Lines,Delicate circuit traces branching in from the edges
+Aqueous Vision,Reef Vertex,Coral fans and sea sponges arranged in a dynamic vertex pattern
+Obscure & Avant-Garde,Wireframe Blossom Field,Flowers made of digital wire outlines fading into the background
+Fragmented Realities,Split Cube Layers,Multiple layers of a cube dissected and sliding apart
+Cyber Tribal,Tribal Mask Overlays,Layered stylized masks stacked in a repeating pattern
+Luminescent Physics,Nanotube Fractal,Repeating carbon tube shapes glowing with embedded light
+Psychological,Optical Illusion,Using perspective tricks in frame design
+Eco-Conscious,Seedling Sprout Frame,"Small plant shoots popping up at corners, suggesting regeneration"
+Obscure & Avant-Garde,Coral Brain Crest,Undulating coral-like shapes with labyrinthine crevices
+Obscure & Avant-Garde,Bone Chapel Ornament,Elaborate borders formed from intricately arranged faux bones
+Myth-Punk Fusion,Piston Cyclops Eye,"One giant, mechanical eye with pistons around the center"
+Surreal Horizons,Ethereal Dusk Fade,Subtle gradient where day dissolves into night along the boundary
+Dreamlike Collisions,Watercolor Wisps,Swashes of gentle watercolor that drift off into nothingness
+Retro-Futurism,80s Gradient Sun,"A massive, stylized sun with stripes, perched behind the subject"
+Mythic Realism,Dragon Spine Border,Scaled ridges weaving along the edges like the spine of a mythical beast
+Anime Fusion,Mecha Armor Trim,Robotic plating and tech details forming a protective shell
+Obscure & Avant-Garde,Shattered Origami,Crisp folded shapes bursting apart into shards at the periphery
+Myth-Punk Fusion,Clockwork Unicorn Horn,A metallic spiral horn with clock gears around its base
+Luminous Color Symphony,Spectral Bleed Edge,Colors from image bleeding outward into frame at decreasing saturation
+Luminous Color Symphony,Chromatic Echo Chamber,Frame colors echo main palette at 30% saturation
+Luminous Color Symphony,Light Frequency Border,Thin bands of pure spectrum wavelengths
+Luminous Color Symphony,Color Temperature Gradient,Frame shifts from warm to cool matching image flow
+Luminous Color Symphony,Prismatic Shatter Corner,Just corners break into rainbow refraction
+Luminous Color Symphony,Neon Surf Crest,Wave-shaped rainbow band riding the bottom rim
+Luminous Color Symphony,Aurora Foam Fringe,Soft multi-hued mist dissolving along edges
+Luminous Color Symphony,Chromatic Spray Arc,High-saturation splash sweeping over corner
+Luminous Color Symphony,Lens-Flare Ripple,Concentric light rings fading from focal point
+Luminous Color Symphony,Iridescent Oil Slick,Thin petroleum rainbow sheen on borders
+Atmospheric Depth Drama,Fog Bank Intrusion,Mist creeping in from edges with varying density
+Atmospheric Depth Drama,Weather Scarring,Frame shows environmental damage matching mood
+Atmospheric Depth Drama,Impasto Echo Ridge,Frame texture matches painting's brushwork weight
+Atmospheric Depth Drama,Chiaroscuro Cutoff,Hard light/shadow edge defining frame boundary
+Atmospheric Depth Drama,Atmospheric Pressure Band,Air density changes visible at borders
+Atmospheric Depth Drama,Patina Drip Trail,Vertical streaks suggesting aged surfaces
+Atmospheric Depth Drama,Verdigris Crackle Web,Green oxidation patterns spreading from corners
+Atmospheric Depth Drama,Rust-Leaf Gild,Oxidised foliage hugging outer rim
+Atmospheric Depth Drama,Ember-Edge Fade,Warm glow dissipating from base
+Atmospheric Depth Drama,Storm Front Border,Dark clouds gathering at frame edges
+Crystalline Precision,Laser Cut Precision,Impossibly clean geometric edge cuts
+Crystalline Precision,Holographic Shift Band,Viewing angle changes frame appearance
+Crystalline Precision,Crystal Growth Edge,Frame appears to be crystallizing
+Crystalline Precision,Mathematical Spiral,Fibonacci/golden ratio visible in frame
+Crystalline Precision,Quantum Interference Pattern,Wave interference patterns at edges
+Crystalline Precision,Mirror Fade Dissolve,Perfect reflection gradually vanishing
+Crystalline Precision,Data Rain Sweep,Vertical code columns at frame sides
+Crystalline Precision,Voxel Ghost Echo,Pixelated afterimages repeating outward
+Crystalline Precision,Circuit Board Trim,Technological patterns etched in border
+Crystalline Precision,Fractal Zoom Border,Infinitely detailed edge patterns
+Organic Flow Magic,Living Edge Crawl,Frame appears to be growing/moving
+Organic Flow Magic,Seasonal Shift Border,Frame shows time passage through seasons
+Organic Flow Magic,Mycelial Network Edge,Connecting threads visible in frame
+Organic Flow Magic,Pollen Drift Halo,Particles floating off frame edges
+Organic Flow Magic,Tidal Breathing Edge,Frame expands/contracts visually
+Organic Flow Magic,Root-Spiral Pavilion,Root systems spiraling from corners
+Organic Flow Magic,Kelp-Shadow Gradient,Underwater plant shadows swaying
+Organic Flow Magic,Petal Flake Fringe,Flower petals scattered along edges
+Organic Flow Magic,Wind-Petal Rotor,Spiraling petals suggesting movement
+Organic Flow Magic,Moss Creep Softening,Organic growth softening hard edges
+Narrative Maximalism,Chapter Break Marks,Visual paragraph indents in frame
+Narrative Maximalism,Marginalia Whispers,Tiny stories written in frame margins
+Narrative Maximalism,Timeline Ticker,Historical progression visible in border
+Narrative Maximalism,Easter Egg Border,Hidden symbols and references
+Narrative Maximalism,Story Thread Weave,Narrative lines connecting through frame
+Narrative Maximalism,Corrupted Timestamp,Glitching time markers along border
+Narrative Maximalism,Echo Slash Shadow,Repeated action marks in frame
+Narrative Maximalism,Rotating Panels,Multiple viewpoints in frame sections
+Narrative Maximalism,Hand Drawn Vistas,Meta-narrative of creation visible
+Narrative Maximalism,Memory Fragment Edge,Torn photo/document edges suggesting past
+Universal Winners,Velvet Nightfall Grain,Deep matte texture for bright images
+Universal Winners,Shadow Petal Sheen,Subtle highlight grazing frame interior
+Universal Winners,Smoke Tendril Vignette,Soft smoke ribbons curling inward
+Universal Winners,Negative Space Halo,Pure breathing room around subject
+Universal Winners,Subtle Glow Rim,Barely visible light outline
+Competition Strategy,90/10 Balance Frame,Frame takes exactly 10% visual weight
+Competition Strategy,Completion Signal,"Professional finish indicating ""done"""
+Competition Strategy,Echo Single Element,Frame echoes ONE aspect only
+Competition Strategy,Breathing Room Border,5-15% negative space guaranteed
+Competition Strategy,Subtlety Gradient,Frame complexity inverse to image complexity
+Gritty Noir,Cigarette Smoke Frame,Wispy plumes of smoke swirling heavily around the perimeter
+Embodied Dreams,Hand Drawn Vistas,Dreamy sceneries literally drawn by giant hands holding pencils
+Folk Art Revival,Wheat Sheaf Corners,"Dry wheat bundles tied at each corner, symbolizing harvest"
+Polyptych,Rotating Panels,Multiple panels with varied orientations
+Rust & Patina,Oxidized Halo,Corroded metal ring with verdigris bloom
+Rust & Patina,Patina Drip Trail,Vertical green-blue streaks bleeding into canvas
+Rust & Patina,Ash-Rose Contrast,Warm rose flakes against cold rust flakes
+Rust & Patina,Sulphur Spark Edge,Tiny yellow-gold pockmarks flickering on border
+Rust & Patina,Verdant Crackle,Leaf-shaped cracks revealing copper underlayer
+Oxidised Reverie,Rust-Leaf Gild,Oxidised leaf gilding hugging the outer rim
+Oxidised Reverie,Pitted Mirror Fade,Weathered mirror texture dissolving outward
+Oxidised Reverie,Corten Halo Strip,Rust-orange band encircling top arc
+Oxidised Reverie,Verdigris Crackle Web,Subtle green crackle pattern in corners
+Oxidised Reverie,Patina Drip Trail,Faint vertical drips suggesting aged metal
+Oxidised Verdigris,Copper-Sea Bloom,Turquoise blooms lapping inner border
+Oxidised Verdigris,Malachite Fringe,Fuzzy malachite edge softening corners
+Oxidised Verdigris,Blue-Green Flake,Speckled verdigris chips dotting frame
+Oxidised Verdigris,Kintsugi Oxide Line,Thin gold repair lines crossing patina bands
+Oxidised Verdigris,Saltspray Fade,Pale salt crystals dusting lower rim
+Corten Horizon,Weather-Steel Bracket,Angular corten plates at each corner
+Corten Horizon,Ember-Edge Fade,Soft ember gradient rising from base
+Corten Horizon,Scale Rust Grain,Coarse rust texture rippling along sides
+Corten Horizon,Sunset Oxide Veil,Thin warm glow just inside outer rim
+Corten Horizon,Char Oxide Speck,Sooty flecks peppering the top border
+Oxide Botanica,Rust-Pollen Tassel,Tiny rust dots clustering like pollen
+Oxide Botanica,Floral Drip Lattice,Delicate drip patterns forming vine mesh
+Oxide Botanica,Leaf-Tarnish Shadow,Oxidised leaf silhouettes ghosting corners
+Oxide Botanica,Seed-Patina Burst,Small seed-shaped rust blooms at mid-edges
+Oxide Botanica,Petal Flake Fringe,Irregular flaked edges echoing petals
+Corrosion Dream,Liquid Metal Vein,Oil-slick ribbons threading inner frame
+Corrosion Dream,Prism Rust Mist,Soft rainbow haze bleeding from rust bands
+Corrosion Dream,Frost Oxide Crack,Chilled blue fissures through patina fields
+Corrosion Dream,Vapor-Dust Curl,Evaporation swirls ghosting along border
+Corrosion Dream,Spectrum Oxide Rain,Fine vertical streaks shifting color
+Lotus Apex,Shadow Petal Sheen,Petal-shaped highlights grazing the frame interior
+Lotus Apex,Smoke Tendril Vignette,Soft smoke ribbons curling inward on all sides
+Lotus Apex,Velvet Nightfall Grain,Deep matte texture giving plush nocturnal backdrop
+Glitch Murmuration,Corrupted Timestamp,Flickering numerals drifting along border path
+Glitch Murmuration,Laser-Fuchsia Trace,Hot-pink streak clipping diagonal corners
+Glitch Murmuration,Data Rainfall Sweep,Vertical code-rain shading inner edge
+Glitch Murmuration,Voxel Ghost Echo,Pixelated after-images repeating outward
+Glitch Murmuration,Noise-Gate Shadow,Binary static biting into frame silhouette
+Solar Halo Pastures,Sun-Halo Lattice,Radiating gold lattice forming airy crown around image
+Solar Halo Pastures,Wind-Petal Rotor,Spiralling petal vanes on side borders
+Solar Halo Pastures,Root-Spiral Pavilion,Root ridges spiralling from lower corners
+Solar Halo Pastures,Chlorophyll Circuit Vein,Fine PCB-like chlorophyll tracery outlining frame
+Solar Halo Pastures,Lumen Seedlights,Miniature seed-LED dots scattered along top band
+Obsidian Lotus Apex,Lotus Bloom Ember,Red-hot lotus crests anchoring each corner
+Obsidian Lotus Apex,Midnight Mirror Trim,Glossy black reflections around inner rim
+Obsidian Lotus Apex,Thorn-Ink Fringe,Sharp barbs jutting intermittently toward center
+Obsidian Lotus Apex,Smoke Tendril Curl,Grey smoke coils licking inward between corners
+Obsidian Lotus Apex,Velvet Night Grain,Plush matte texture softening the entire backdrop
+Root & Reef,Kelp-Shadow Gradient,Soft vertical fade resembling kelp sway
+Root & Reef,Melt-Drip Ghost,Semi-transparent drips freezing mid-air
+Bloom & Blade,Silk-Ash Fallout,Ghostly silk fibers mingling with ash particles
+Bloom & Blade,Echo Slash Shadow,Repeated diagonal gashes casting long shadows
+Verdigris Stellar,Oxide Halo Arc,Crescent of glowing verdigris framing the upper edge
+Verdigris Stellar,Malachite Dust Veil,Fine green patina speckles drifting inward from corners
+Verdigris Stellar,Kintsugi Star Crack,Hair-thin gold fissures radiating out like constellations
+Verdigris Stellar,Patina Drip Border,Vertical turquoise drips marking side margins
+Verdigris Stellar,Antique Filigree Trace,Delicate bronze scrollwork hugging the inner frame
+Prism Tide,Neon Surf Crest,Wave-shaped rainbow band riding the bottom rim
+Prism Tide,Aurora Foam Fringe,Soft multi-hued mist dissolving along left edge
+Prism Tide,Coral Rust Splatter,Orange-red oxide flecks sprayed diagonally across corners
+Prism Tide,Chromatic Spray Arc,High-saturation splash sweeping over top-right quadrant
+Prism Tide,Lens-Flare Ripple,Concentric light rings fading from a single corner source
+Glitch Petal,Corrupted Timestamp Strip,Flickering numeric glyphs stitched along bottom border
+Glitch Petal,Pixel Bloom Burst,Cluster of 8-bit floral pixels exploding off one edge
+Glitch Petal,Data Rain Sweep,Vertical code-rain columns descending at frame sides
+Glitch Petal,Voxel Ghost Halo,Semi-transparent cubes echoing the main form at margins
+Glitch Petal,CRT Phosphor Smear,Horizontal colour-bleed streak near top border
+Ember Corten,Magma Vein Edge,Red-orange molten cracks tracing the frame interior
+Ember Corten,Charcoal Fade Band,Deep gradient bar grounding the piece at the base
+Ember Corten,Spark Ash Drift,Tiny ember particles drifting upward from lower corners
+Ember Corten,Steel Scale Grain,Coarse rust-scale texture mottling the side borders
+Ember Corten,Smelt Glow Rim,Subtle incandescent outline hugging the silhouette
+Aether Nocturne,Star-Dust Scatter,Sparse golden specks floating in the negative space
+Aether Nocturne,Lunar Crescent Clip,Thin silver arc partially intruding from upper-left
+Aether Nocturne,Nebula Wisp Curtain,Feathered nebular haze draped on right side
+Aether Nocturne,Shadow Void Pocket,Pure matte zone occupying 10% background for breathing room
+Aether Nocturne,Comet Tail Streak,Soft diagonal light streak guiding eye toward focal point

--- a/lofn/ui.py
+++ b/lofn/ui.py
@@ -874,6 +874,7 @@ class LofnApp:
                     model=self.model,
                     debug=self.debug,
                     reasoning_level=st.session_state.get('reasoning_level','medium'),
+                    medium="video",
                     personality_prompt=personality_text,
                 )
                 st.session_state['meta_prompt'] = meta_prompt['meta_prompt']


### PR DESCRIPTION
## Summary
- add `sample_video_frames` helper and import into `llm_integration.py`
- use `video_frames.csv` when generating video meta prompts; image prompts still use `frames.csv`
- pass `medium="video"` from UI for video meta prompt creation
- include new `video_frames.csv` dataset

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688d70786240832980638d54e69a8ac2