### PR TITLE
Load art and film styles into image and video prompts

### DIFF
--- a/lofn/helpers.py
+++ b/lofn/helpers.py
@@ -69,6 +69,28 @@ def sample_music_genres(min_count: int = 40, max_count: int = 50) -> str:
     return "\n".join(sampled)
 
 
+def sample_art_styles(min_count: int = 40, max_count: int = 50) -> str:
+    """Return a newline-separated list of randomly selected rare art styles."""
+    path = os.path.join(os.path.dirname(__file__), 'prompts', 'aesthetics.txt')
+    with open(path, 'r') as file:
+        styles = [s.strip() for s in file.read().split(',') if s.strip()]
+
+    count = random.randint(min_count, max_count)
+    sampled = random.sample(styles, count)
+    return "\n".join(sampled)
+
+
+def sample_film_styles(min_count: int = 40, max_count: int = 50) -> str:
+    """Return a newline-separated list of randomly selected film styles."""
+    path = os.path.join(os.path.dirname(__file__), 'prompts', 'film_styles.txt')
+    with open(path, 'r') as file:
+        styles = [line.strip() for line in file.readlines() if line.strip()]
+
+    count = random.randint(min_count, max_count)
+    sampled = random.sample(styles, count)
+    return "\n".join(sampled)
+
+
 def sample_music_frames(min_count: int = 40, max_count: int = 50) -> str:
     """Return a newline-separated list of randomly selected music frames."""
     path = os.path.join(os.path.dirname(__file__), 'prompts', 'music_frames.csv')

--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -32,6 +32,8 @@ from helpers import (
     sample_video_frames,
     sample_music_frames,
     sample_music_genres,
+    sample_art_styles,
+    sample_film_styles,
 )
 import plotly.graph_objects as go
 import random
@@ -1530,13 +1532,13 @@ def generate_meta_prompt(
     try:
         if medium == "music":
             frames_list = sample_music_frames()
-            genres_list = sample_music_genres()
+            styles_list = sample_music_genres()
         elif medium == "video":
             frames_list = sample_video_frames()
-            genres_list = None
+            styles_list = sample_film_styles()
         else:
             frames_list = sample_artistic_frames()
-            genres_list = None
+            styles_list = sample_art_styles()
         llm = get_llm(model, temperature, Config.OPENAI_API, Config.ANTHROPIC_API, debug, reasoning_level)
         if model[0] == "o":
             chain = (
@@ -1551,37 +1553,21 @@ def generate_meta_prompt(
 
         full_input = f"{personality_prompt}\n\n{input_text}" if personality_prompt else input_text
 
-        if medium == "music":
-            parsed_output = run_llm_chain(
-                {'meta': chain},
-                'meta',
-                {
-                    'input': full_input,
-                    'genres_list': genres_list,
-                    'frames_list': frames_list,
-                    'personality_prompt': personality_prompt,
-                },
-                max_retries,
-                model,
-                debug,
-                expected_schema=meta_prompt_schema,
-            )
-            return parsed_output, frames_list, genres_list
-        else:
-            parsed_output = run_llm_chain(
-                {'meta': chain},
-                'meta',
-                {
-                    'input': full_input,
-                    'frames_list': frames_list,
-                    'personality_prompt': personality_prompt,
-                },
-                max_retries,
-                model,
-                debug,
-                expected_schema=meta_prompt_schema,
-            )
-            return parsed_output, frames_list
+        parsed_output = run_llm_chain(
+            {'meta': chain},
+            'meta',
+            {
+                'input': full_input,
+                'frames_list': frames_list,
+                'styles_list': styles_list,
+                'personality_prompt': personality_prompt,
+            },
+            max_retries,
+            model,
+            debug,
+            expected_schema=meta_prompt_schema,
+        )
+        return parsed_output, frames_list, styles_list
     except Exception as e:
         logger.exception("Error generating meta prompt: %s", e)
         raise e

--- a/lofn/prompts/film_styles.txt
+++ b/lofn/prompts/film_styles.txt
@@ -1,0 +1,59 @@
+German Expressionism
+Italian Neorealism
+French New Wave
+Soviet Montage
+Dogme 95
+Giallo
+Spaghetti Western
+Cinema Verite
+Mumblecore
+Slow Cinema
+Kitchen Sink Realism
+Surrealist Cinema
+Film Noir
+Avant-garde
+Neo-Noir
+New Hollywood
+Anime
+Bollywood Masala
+Wuxia
+Samurai Cinema
+Hong Kong Action
+Chambara
+Kaiju
+Pinku Eiga
+Blaxploitation
+Nunsploitation
+Sword-and-Sandal
+Acid Western
+Psychedelic Cinema
+Experimental Film
+Mockumentary
+Docufiction
+Found Footage
+Anthology Film
+Nonlinear Narrative
+Minimalist Film
+Magical Realism
+Queer Cinema
+Postmodern Pastiche
+Biopunk
+Steampunk
+Cyberpunk
+Dieselpunk
+Vaporwave Film
+Retro-futurism
+Poetic Realism
+Expressionist Animation
+Stop-motion
+Claymation
+Rotoscoped Live-Action
+Pixelation
+Hyperreal CGI
+Split-Screen Montage
+Oneiric Cinema
+Noir Western
+Epic Historical Drama
+Social Realism
+Gothic Horror
+Glam Rock Musical

--- a/lofn/prompts/overall_prompt_template.txt
+++ b/lofn/prompts/overall_prompt_template.txt
@@ -9,6 +9,11 @@ The user may ask for a panel of experts to help. When they do, select a panel of
 - You have at least 5 retries to work with, so use them to make sure you are thorough!
 - Use as many messages and tokens as required to complete everything.
 
+# Rare Art Style List
+```tab-delim
+{art_styles_list}
+```
+
 # Begin User’s Request
 Please follow this advaned directive:
 {Meta-Prompt}

--- a/lofn/prompts/video_overall_prompt_template.txt
+++ b/lofn/prompts/video_overall_prompt_template.txt
@@ -9,6 +9,11 @@ The user may ask for a panel of experts to help. When they do, select a panel of
 - You have at least 5 retries to work with, so use them to make sure you are thorough!
 - Use as many messages and tokens as required to complete everything.
 
+# Film Style List
+```tab-delim
+{film_styles_list}
+```
+
 # Begin User’s Request
 Please follow this advaned directive:
 {Meta-Prompt}

--- a/lofn/ui.py
+++ b/lofn/ui.py
@@ -485,7 +485,7 @@ class LofnApp:
                         st.session_state['custom_personality'] = personality_text
                     display_temporary_results("Personality", personality_text, expanded=False)
 
-                meta_prompt, frames_list = generate_meta_prompt(
+                meta_prompt, frames_list, art_styles_list = generate_meta_prompt(
                     st.session_state.get('input', ''),
                     max_retries=self.max_retries,
                     temperature=self.temperature,
@@ -515,6 +515,7 @@ class LofnApp:
                     .replace('{Panel-prompt}', panel_text)
                     .replace('{Personality-prompt}', personality_text)
                     .replace('{frames_list}', frames_list)
+                    .replace('{art_styles_list}', art_styles_list)
                     .replace('{input}', st.session_state.get('input', ''))
                 )
                 display_temporary_results("Meta Prompt", meta_prompt['meta_prompt'], expanded=False)
@@ -867,7 +868,7 @@ class LofnApp:
                         )
                         st.session_state['custom_personality'] = personality_text
                     display_temporary_results("Personality", personality_text, expanded=False)
-                meta_prompt, frames_list = generate_meta_prompt(
+                meta_prompt, frames_list, film_styles_list = generate_meta_prompt(
                     st.session_state.get('input', ''),
                     max_retries=self.max_retries,
                     temperature=self.temperature,
@@ -898,6 +899,7 @@ class LofnApp:
                     .replace('{Panel-prompt}', panel_text)
                     .replace('{Personality-prompt}', personality_text)
                     .replace('{frames_list}', frames_list)
+                    .replace('{film_styles_list}', film_styles_list)
                     .replace('{input}', st.session_state.get('input', ''))
                 )
                 display_temporary_results("Meta Prompt", meta_prompt['meta_prompt'], expanded=False)

--- a/tests/test_art_styles.py
+++ b/tests/test_art_styles.py
@@ -1,0 +1,31 @@
+import sys
+import os
+import types
+
+# Stub dependencies
+streamlit_stub = types.SimpleNamespace(session_state={})
+sys.modules['streamlit'] = streamlit_stub
+sys.modules['requests'] = types.SimpleNamespace(post=lambda *a, **k: None)
+sys.modules['json_repair'] = types.SimpleNamespace(repair_json=lambda s: s)
+
+plotly_module = types.ModuleType("plotly")
+graph_objects_module = types.ModuleType("plotly.graph_objects")
+plotly_module.graph_objects = graph_objects_module
+sys.modules['plotly'] = plotly_module
+sys.modules['plotly.graph_objects'] = graph_objects_module
+
+# Make repo root importable
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, REPO_ROOT)
+
+import importlib
+config_module = importlib.import_module('lofn.config')
+sys.modules['config'] = config_module
+from lofn.helpers import sample_art_styles
+
+
+def test_sample_art_styles_returns_lines():
+    data = sample_art_styles(min_count=5, max_count=5)
+    lines = data.split('\n')
+    assert len(lines) == 5
+    assert all(line for line in lines)

--- a/tests/test_film_styles.py
+++ b/tests/test_film_styles.py
@@ -1,0 +1,31 @@
+import sys
+import os
+import types
+
+# Stub dependencies
+streamlit_stub = types.SimpleNamespace(session_state={})
+sys.modules['streamlit'] = streamlit_stub
+sys.modules['requests'] = types.SimpleNamespace(post=lambda *a, **k: None)
+sys.modules['json_repair'] = types.SimpleNamespace(repair_json=lambda s: s)
+
+plotly_module = types.ModuleType("plotly")
+graph_objects_module = types.ModuleType("plotly.graph_objects")
+plotly_module.graph_objects = graph_objects_module
+sys.modules['plotly'] = plotly_module
+sys.modules['plotly.graph_objects'] = graph_objects_module
+
+# Make repo root importable
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, REPO_ROOT)
+
+import importlib
+config_module = importlib.import_module('lofn.config')
+sys.modules['config'] = config_module
+from lofn.helpers import sample_film_styles
+
+
+def test_sample_film_styles_returns_lines():
+    data = sample_film_styles(min_count=5, max_count=5)
+    lines = data.split('\n')
+    assert len(lines) == 5
+    assert all(line for line in lines)


### PR DESCRIPTION
## Summary
- sample rare art styles and film styles from new helper utilities
- embed these styles into meta prompts and UI templates for image and video generation
- add film style dataset and tests for style sampling helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d72baf5648329bea501e699e70809