### PR TITLE
feat: add gpt-5 model support

### DIFF
--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -569,6 +569,9 @@ def get_llm(model, temperature, OPENAI_API=None, ANTHROPIC_API=None, debug=False
         # Dictionary mapping models to their maximum token limits
         model_max_tokens = {
             # OpenAI models
+            "gpt-5": 32768,
+            "gpt-5-mini": 32768,
+            "gpt-5-nano": 32768,
             "gpt-4.1": 32768,
             "gpt-4.1-mini": 32768,
             "gpt-4.1-nano": 32768,
@@ -602,6 +605,9 @@ def get_llm(model, temperature, OPENAI_API=None, ANTHROPIC_API=None, debug=False
             "gemini-1.5-flash-search": 16384,
 
             # Poe models
+            "Poe-GPT-5": 32768,
+            "Poe-GPT-5-mini": 32768,
+            "Poe-GPT-5-nano": 32768,
             "Poe-GPT-4.1": 32768,
             "Poe-GPT-4.1-mini": 32768,
             "Poe-GPT-4.1-nano": 32768,

--- a/lofn/model_defaults.yaml
+++ b/lofn/model_defaults.yaml
@@ -8,6 +8,7 @@ art:
     - Poe-Grok-4
   prompt:
     - OR-openrouter/horizon-alpha
+    - gpt-5
     - gpt-4.1
     - Poe-Gemini-2.5-Flash
     - gemini-2.5-flash
@@ -22,6 +23,7 @@ video:
     - Poe-Grok-4
   prompt:
     - OR-openrouter/horizon-alpha
+    - gpt-5
     - gpt-4.1
     - Poe-Gemini-2.5-Flash
     - gemini-2.5-flash

--- a/lofn/ui.py
+++ b/lofn/ui.py
@@ -74,6 +74,7 @@ class LofnApp:
         # Add OpenAI-based models if OPENAI_API is available
         if Config.OPENAI_API:
             models.extend([
+                "gpt-5", "gpt-5-mini", "gpt-5-nano",
                 "gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano",
                 "o3", "o3-pro", "o4-mini"
             ])
@@ -96,6 +97,7 @@ class LofnApp:
         # Add Poe models if POE_API is available
         if Config.POE_API:
             models.extend([
+                "Poe-GPT-5", "Poe-GPT-5-mini", "Poe-GPT-5-nano",
                 "Poe-GPT-4.1", "Poe-GPT-4.1-mini", "Poe-GPT-4.1-nano",
                 "Poe-o3", "Poe-o3-pro", "Poe-o4-mini",
                 "Poe-Claude-Opus-4", "Poe-Claude-Sonnet-4",
@@ -201,7 +203,9 @@ class LofnApp:
         if model is None:
             model = self.available_models[0] if self.available_models else None
         if prompt_model is None:
-            if 'gpt-4.1' in self.available_models:
+            if 'gpt-5' in self.available_models:
+                prompt_model = 'gpt-5'
+            elif 'gpt-4.1' in self.available_models:
                 prompt_model = 'gpt-4.1'
             else:
                 prompt_model = self.available_models[0] if self.available_models else None


### PR DESCRIPTION
## Summary
- support gpt-5, gpt-5-mini, and gpt-5-nano alongside existing GPT models
- prioritize gpt-5 in default model selections and defaults
- include gpt-5 options in model defaults for art and video prompts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68955a0c943c8329a6b950680c0bcd1a