### PR TITLE
Add search-capable models to LLM list

### DIFF
--- a/lofn/helpers.py
+++ b/lofn/helpers.py
@@ -307,6 +307,14 @@ def filter_models_by_context_length(models, min_total_tokens=25000, min_response
                 })
     return filtered_models
 
+def filter_models_by_capability(models, capability):
+    filtered_models = []
+    for model in models:
+        capabilities = model.get('capabilities', []) or model.get('tools', [])
+        if capability in capabilities:
+            filtered_models.append(model)
+    return filtered_models
+
 def get_step_name(process_name, step):
     steps = {
         "Concept Medium Generation": [

--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -578,6 +578,15 @@ def get_llm(model, temperature, OPENAI_API=None, ANTHROPIC_API=None, debug=False
             "o3": 100000,
             "o3-pro": 100000,
             "o4-mini": 100000,
+            "gpt-5-search": 32768,
+            "gpt-5-mini-search": 32768,
+            "gpt-5-nano-search": 32768,
+            "gpt-4.1-search": 32768,
+            "gpt-4.1-mini-search": 32768,
+            "gpt-4.1-nano-search": 32768,
+            "o3-search": 100000,
+            "o3-pro-search": 100000,
+            "o4-mini-search": 100000,
 
             # Anthropic models
             "claude-3-7-sonnet-20250219": 32000,
@@ -590,6 +599,16 @@ def get_llm(model, temperature, OPENAI_API=None, ANTHROPIC_API=None, debug=False
             "claude-3-opus-20240229": 4096,
             "claude-3-sonnet-20240229": 4096,
             "claude-3-haiku-20240307": 4096,
+            "claude-3-7-sonnet-20250219-search": 32000,
+            "claude-sonnet-4-20250514-search": 32000,
+            "claude-opus-4-20250514-search": 32000,
+            "claude-3-5-sonnet-latest-search": 8096,
+            "claude-3-5-sonnet-20241022-search": 8096,
+            "claude-3-5-haiku-20241022-search": 8096,
+            "claude-3-5-sonnet-20240620-search": 4096,
+            "claude-3-opus-20240229-search": 4096,
+            "claude-3-sonnet-20240229-search": 4096,
+            "claude-3-haiku-20240307-search": 4096,
 
             # Google models
             "gemini-2.5-pro": 120000,

--- a/lofn/ui.py
+++ b/lofn/ui.py
@@ -76,7 +76,10 @@ class LofnApp:
             models.extend([
                 "gpt-5", "gpt-5-mini", "gpt-5-nano",
                 "gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano",
-                "o3", "o3-pro", "o4-mini"
+                "o3", "o3-pro", "o4-mini",
+                "gpt-5-search", "gpt-5-mini-search", "gpt-5-nano-search",
+                "gpt-4.1-search", "gpt-4.1-mini-search", "gpt-4.1-nano-search",
+                "o3-search", "o3-pro-search", "o4-mini-search"
             ])
         # Add Anthropic models if ANTHROPIC_API is available
         if Config.ANTHROPIC_API:
@@ -85,7 +88,12 @@ class LofnApp:
                 "claude-3-5-sonnet-latest", "claude-3-5-haiku-20241022",
                 "claude-3-5-sonnet-20241022", "claude-3-5-sonnet-20240620",
                 "claude-3-opus-20240229", "claude-3-sonnet-20240229",
-                "claude-3-haiku-20240307"
+                "claude-3-haiku-20240307",
+                "claude-3-7-sonnet-20250219-search", "claude-sonnet-4-20250514-search", "claude-opus-4-20250514-search",
+                "claude-3-5-sonnet-latest-search", "claude-3-5-haiku-20241022-search",
+                "claude-3-5-sonnet-20241022-search", "claude-3-5-sonnet-20240620-search",
+                "claude-3-opus-20240229-search", "claude-3-sonnet-20240229-search",
+                "claude-3-haiku-20240307-search"
             ])
         # Add Google models if GOOGLE_API is available
         if Config.GOOGLE_API:
@@ -116,8 +124,9 @@ class LofnApp:
             try:
                 or_models = fetch_openrouter_models()
                 if or_models:
+                    search_models = filter_models_by_capability(or_models, 'search')
                     filtered_or_models = filter_models_by_context_length(
-                        or_models, min_total_tokens=25000, min_response_tokens=15000
+                        search_models, min_total_tokens=25000, min_response_tokens=15000
                     )
                     # Extract model IDs
                     models.extend(['OR-'+m['id'] for m in filtered_or_models])


### PR DESCRIPTION
## Summary
- Add helper to filter models by capability
- Populate OpenAI and Anthropic search variants in available model list and token limits
- Restrict OpenRouter models to those supporting search before applying context filter

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897e4c3d44483299a0610adfc5100a8