### PR TITLE
Fix meta/panel prompt input handling for video generation

### DIFF
--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -1657,7 +1657,12 @@ def generate_meta_prompt(
                 | llm
             )
 
-        full_input = f"{personality_prompt}\n\n{input_text}" if personality_prompt else input_text
+        # Only pass the user's text as the main input. The personality prompt is
+        # supplied separately in the prompt template via the
+        # ``personality_prompt`` variable, so prepending it here would cause the
+        # generated meta-prompt to over-index on personality and ignore the
+        # user's request.
+        full_input = input_text
 
         parsed_output = run_llm_chain(
             {'meta': chain},
@@ -1702,7 +1707,11 @@ def generate_panel_prompt(
                 | llm
             )
 
-        full_input = f"{personality_prompt}\n\n{input_text}" if personality_prompt else input_text
+        # Similar to meta-prompt generation, keep the user's request separate
+        # from any optional personality prompt. The prompt template already has
+        # a ``personality_prompt`` field, so including it in the ``input`` would
+        # duplicate content and potentially drown out the user's text.
+        full_input = input_text
 
         parsed_output = run_llm_chain(
             {"panel": chain},


### PR DESCRIPTION
## Summary
- Ensure meta prompt generation uses the user's text separately from personality prompts
- Do the same for panel prompt generation so user instructions aren't lost

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898ed1fbd8483299462336d87c58ba9