### PR TITLE
Add streaming support for personality chat

### DIFF
--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -1793,6 +1793,72 @@ def run_personality_chat(
         return response.content
     return str(response)
 
+
+async def stream_personality_chat(
+    personality_prompt,
+    chat_history,
+    user_input,
+    model="gpt-3.5-turbo-16k",
+    temperature=0.7,
+    reasoning_level="medium",
+    debug=False,
+):
+    """Stream a free-form chat response with a given personality.
+
+    This function mirrors ``run_personality_chat`` but yields tokens as they
+    arrive from the underlying LLM.  If streaming is unavailable for the
+    selected model it falls back to returning the full response in one chunk.
+    """
+
+    # Build the chain using the same prompt setup as the non-streaming version
+    llm = get_llm(
+        model,
+        temperature,
+        Config.OPENAI_API,
+        Config.ANTHROPIC_API,
+        debug,
+        reasoning_level,
+    )
+
+    readme_path = Path('/workspace/lofn/README.md')
+    lofn_readme = readme_path.read_text() if readme_path.exists() else ""
+
+    prompt = ChatPromptTemplate.from_messages([
+        ("system", personality_chat_template),
+        MessagesPlaceholder("chat_history"),
+        ("human", "{input}"),
+    ])
+
+    chain = prompt | llm
+    inputs = {
+        "personality": personality_prompt,
+        "lofn_readme": lofn_readme,
+        "chat_history": chat_history,
+        "input": user_input,
+    }
+
+    callback = AsyncIteratorCallbackHandler()
+
+    try:
+        task = asyncio.create_task(chain.astream(inputs, callbacks=[callback]))
+
+        async for token in callback.aiter():
+            yield token
+
+        await task
+    except Exception:
+        # If streaming isn't supported, fall back to the blocking call
+        fallback = run_personality_chat(
+            personality_prompt,
+            chat_history,
+            user_input,
+            model=model,
+            temperature=temperature,
+            reasoning_level=reasoning_level,
+            debug=debug,
+        )
+        yield fallback
+
 @st.cache_data(persist=True)
 def select_best_pairs(input_text, pairs, num_best_pairs, max_retries, temperature, model="gpt-3.5-turbo-16k", debug=False, reasoning_level="medium"):
     """Use the panel to vote on the best concept-medium pairs."""

--- a/lofn/ui.py
+++ b/lofn/ui.py
@@ -1516,7 +1516,7 @@ class LofnApp:
             st.session_state['chat_history'].append(HumanMessage(content=user_input))
             with st.chat_message("user"):
                 st.markdown(user_input)
-            response_text = run_personality_chat(
+            response_stream = stream_personality_chat(
                 personality_text,
                 history,
                 user_input,
@@ -1525,9 +1525,9 @@ class LofnApp:
                 reasoning_level=st.session_state.get('reasoning_level', 'medium'),
                 debug=self.debug,
             )
-            st.session_state['chat_history'].append(AIMessage(content=response_text))
             with st.chat_message("assistant"):
-                st.markdown(response_text)
+                response_text = st.write_stream(response_stream)
+            st.session_state['chat_history'].append(AIMessage(content=response_text))
 
     def initialize_session_state(self):
         cm_model, prompt_model = self.get_defaults_for_mode('Image Generation')


### PR DESCRIPTION
## Summary
- add `stream_personality_chat` to yield tokens as they arrive from the LLM
- wire Streamlit chat UI to stream responses using `st.write_stream`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a6f5577b48329a762cfe7a0c59f17