### PR TITLE
Fix Streamlit async streaming error

### DIFF
--- a/lofn/helpers.py
+++ b/lofn/helpers.py
@@ -7,7 +7,10 @@ import requests
 import random
 import json_repair
 import csv
-from typing import Union, List
+import asyncio
+import threading
+from queue import Queue
+from typing import Union, List, AsyncGenerator, Generator
 from datetime import datetime
 import os
 from config import Config
@@ -572,3 +575,35 @@ def send_to_discord(content, content_type='prompts', premessage=''):
                     requests.post(st.session_state['webhook_url'], data=json.dumps(message), headers={"Content-Type": "application/json"})
     except Exception as e:
         st.write(f"An error occurred while sending to Discord: {str(e)}")
+
+
+def async_to_sync_generator(async_gen: AsyncGenerator[str, None]) -> Generator[str, None, None]:
+    """Convert an async generator into a synchronous generator.
+
+    This helper runs the provided async generator in a background thread and
+    yields items as they are produced. It allows components such as
+    ``st.write_stream`` to consume async sources.
+    """
+
+    queue: Queue[str | None] = Queue()
+
+    async def produce():
+        try:
+            async for item in async_gen:
+                queue.put(item)
+        finally:
+            queue.put(None)
+
+    def runner():
+        asyncio.run(produce())
+
+    thread = threading.Thread(target=runner, daemon=True)
+    thread.start()
+
+    while True:
+        item = queue.get()
+        if item is None:
+            break
+        yield item
+
+    thread.join()

--- a/lofn/ui.py
+++ b/lofn/ui.py
@@ -1531,7 +1531,9 @@ class LofnApp:
                 debug=self.debug,
             )
             with st.chat_message("assistant"):
-                response_text = st.write_stream(response_stream)
+                response_text = st.write_stream(
+                    async_to_sync_generator(response_stream)
+                )
             st.session_state['chat_history'].append(AIMessage(content=response_text))
 
     def initialize_session_state(self):

--- a/tests/test_async_stream.py
+++ b/tests/test_async_stream.py
@@ -1,0 +1,36 @@
+import sys
+import os
+import types
+
+# Stub dependencies not available in the test environment
+sys.modules['streamlit'] = types.SimpleNamespace(write=lambda *a, **k: None, code=lambda *a, **k: None)
+sys.modules['requests'] = types.SimpleNamespace(post=lambda *a, **k: None)
+sys.modules['json_repair'] = types.SimpleNamespace(repair_json=lambda s: s)
+
+plotly_module = types.ModuleType("plotly")
+graph_objects_module = types.ModuleType("plotly.graph_objects")
+plotly_module.graph_objects = graph_objects_module
+sys.modules['plotly'] = plotly_module
+sys.modules['plotly.graph_objects'] = graph_objects_module
+
+# Make repository root importable so ``lofn`` becomes a package
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, REPO_ROOT)
+
+# Ensure ``config`` module resolves to ``lofn.config``
+import importlib
+config_module = importlib.import_module('lofn.config')
+sys.modules['config'] = config_module
+
+from lofn.helpers import async_to_sync_generator
+import asyncio
+
+
+async def dummy_stream():
+    for token in ["a", "b", "c"]:
+        yield token
+
+
+def test_async_to_sync_generator():
+    gen = async_to_sync_generator(dummy_stream())
+    assert list(gen) == ["a", "b", "c"]


### PR DESCRIPTION
## Summary
- add helper to convert async generators into sync generators for Streamlit
- use the helper in the personality chat UI to stream replies
- add test covering the async-to-sync generator utility

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a9ffc9b6c83299f3b4322083242d7