### PR TITLE
Handle image context in meta and personality prompts

### DIFF
--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -1641,6 +1641,7 @@ def generate_meta_prompt(
     reasoning_level="medium",
     medium="image",
     personality_prompt="",
+    input_images: Optional[List[str]] = None,
 ):
     try:
         if medium == "music":
@@ -1652,15 +1653,23 @@ def generate_meta_prompt(
         else:
             frames_list = sample_artistic_frames()
             styles_list = sample_art_styles()
+        image_context = prepare_image_messages(input_images)
         llm = get_llm(model, temperature, Config.OPENAI_API, Config.ANTHROPIC_API, debug, reasoning_level)
         if model[0] == "o":
             chain = (
-                ChatPromptTemplate.from_messages([("human", meta_prompt_generation_prompt)])
+                ChatPromptTemplate.from_messages([
+                    MessagesPlaceholder("image_context"),
+                    ("human", meta_prompt_generation_prompt),
+                ])
                 | llm
             )
         else:
             chain = (
-                ChatPromptTemplate.from_messages([("system", concept_system), ("human", meta_prompt_generation_prompt)])
+                ChatPromptTemplate.from_messages([
+                    ("system", concept_system),
+                    MessagesPlaceholder("image_context"),
+                    ("human", meta_prompt_generation_prompt),
+                ])
                 | llm
             )
 
@@ -1672,13 +1681,14 @@ def generate_meta_prompt(
         full_input = input_text
 
         parsed_output = run_llm_chain(
-            {'meta': chain},
-            'meta',
+            {"meta": chain},
+            "meta",
             {
-                'input': full_input,
-                'frames_list': frames_list,
-                'styles_list': styles_list,
-                'personality_prompt': personality_prompt,
+                "input": full_input,
+                "frames_list": frames_list,
+                "styles_list": styles_list,
+                "personality_prompt": personality_prompt,
+                "image_context": image_context,
             },
             max_retries,
             model,
@@ -1699,18 +1709,27 @@ def generate_panel_prompt(
     debug=False,
     reasoning_level="medium",
     personality_prompt="",
+    input_images: Optional[List[str]] = None,
 ):
     """Generate an artistic panel description via the LLM."""
     try:
+        image_context = prepare_image_messages(input_images)
         llm = get_llm(model, temperature, Config.OPENAI_API, Config.ANTHROPIC_API, debug, reasoning_level)
         if model[0] == "o":
             chain = (
-                ChatPromptTemplate.from_messages([("human", panel_generation_prompt)])
+                ChatPromptTemplate.from_messages([
+                    MessagesPlaceholder("image_context"),
+                    ("human", panel_generation_prompt),
+                ])
                 | llm
             )
         else:
             chain = (
-                ChatPromptTemplate.from_messages([("system", concept_system), ("human", panel_generation_prompt)])
+                ChatPromptTemplate.from_messages([
+                    ("system", concept_system),
+                    MessagesPlaceholder("image_context"),
+                    ("human", panel_generation_prompt),
+                ])
                 | llm
             )
 
@@ -1723,7 +1742,11 @@ def generate_panel_prompt(
         parsed_output = run_llm_chain(
             {"panel": chain},
             "panel",
-            {"input": full_input, "personality_prompt": personality_prompt},
+            {
+                "input": full_input,
+                "personality_prompt": personality_prompt,
+                "image_context": image_context,
+            },
             max_retries,
             model,
             debug,
@@ -1739,23 +1762,45 @@ def generate_panel_prompt(
         raise e
 
 @st.cache_data(persist=True)
-def generate_personality_prompt(input_text, max_retries, temperature, model="gpt-3.5-turbo-16k", debug=False, reasoning_level="medium"):
+def generate_personality_prompt(
+    input_text,
+    max_retries,
+    temperature,
+    model="gpt-3.5-turbo-16k",
+    debug=False,
+    reasoning_level="medium",
+    input_images: Optional[List[str]] = None,
+):
     """Generate a short personality description via the LLM."""
     try:
+        image_context = prepare_image_messages(input_images)
         llm = get_llm(model, temperature, Config.OPENAI_API, Config.ANTHROPIC_API, debug, reasoning_level)
         if model[0] == "o":
             chain = (
-                ChatPromptTemplate.from_messages([("human", personality_generation_prompt)])
+                ChatPromptTemplate.from_messages([
+                    MessagesPlaceholder("image_context"),
+                    ("human", personality_generation_prompt),
+                ])
                 | llm
             )
         else:
             chain = (
-                ChatPromptTemplate.from_messages([("system", concept_system), ("human", personality_generation_prompt)])
+                ChatPromptTemplate.from_messages([
+                    ("system", concept_system),
+                    MessagesPlaceholder("image_context"),
+                    ("human", personality_generation_prompt),
+                ])
                 | llm
             )
 
         parsed_output = run_llm_chain(
-            {"personality": chain}, "personality", {"input": input_text}, max_retries, model, debug, expected_schema=personality_prompt_schema
+            {"personality": chain},
+            "personality",
+            {"input": input_text, "image_context": image_context},
+            max_retries,
+            model,
+            debug,
+            expected_schema=personality_prompt_schema,
         )
         if parsed_output is not None:
             return parsed_output.get("personality_prompt", "")

--- a/lofn/ui.py
+++ b/lofn/ui.py
@@ -600,6 +600,7 @@ class LofnApp:
             st.session_state['concept_mediums'] = []
             st.session_state['progress_step'] = 0
             input_text = st.session_state['input']
+            images = st.session_state.get('input_images')
             if st.session_state.get('competition_mode'):
                 personality_text = st.session_state.get('custom_personality', '')
                 if st.session_state.get('selected_personality') == 'LLM Generated':
@@ -610,7 +611,8 @@ class LofnApp:
                             self.temperature,
                             self.model,
                             self.debug,
-                            st.session_state.get('reasoning_level', 'medium')
+                            st.session_state.get('reasoning_level', 'medium'),
+                            input_images=images,
                         )
                         st.session_state['custom_personality'] = personality_text
                     display_temporary_results("Personality", personality_text, expanded=False)
@@ -623,6 +625,7 @@ class LofnApp:
                     debug=self.debug,
                     reasoning_level=st.session_state.get('reasoning_level', 'medium'),
                     personality_prompt=personality_text,
+                    input_images=images,
                 )
                 st.session_state['meta_prompt'] = meta_prompt['meta_prompt']
                 panel_text = st.session_state.get('custom_panel', '')
@@ -636,6 +639,7 @@ class LofnApp:
                             self.debug,
                             st.session_state.get('reasoning_level', 'medium'),
                             personality_prompt=personality_text,
+                            input_images=images,
                         )
                         st.session_state['custom_panel'] = panel_text
                     display_temporary_results("Panel Prompt", panel_text, expanded=False)
@@ -647,11 +651,12 @@ class LofnApp:
                     .replace('{frames_list}', frames_list)
                     .replace('{art_styles_list}', art_styles_list)
                     .replace('{input}', st.session_state.get('input', ''))
+                    .replace('{image_context}', "\n".join(images) if images else "")
                 )
                 display_temporary_results("Meta Prompt", meta_prompt['meta_prompt'], expanded=False)
-            images = st.session_state.get('input_images')
-            if images:
-                input_text = f"{input_text}\n\nReference Images:\n" + "\n".join(images)
+            else:
+                if images:
+                    input_text = f"{input_text}\n\nReference Images:\n" + "\n".join(images)
             st.session_state['prompt_input'] = input_text
             with st.spinner("Generating concepts..."):
                 concepts, style_axes, creativity_spectrum = generate_concept_mediums(
@@ -818,6 +823,7 @@ class LofnApp:
 
     def run_music_competition(self):
         try:
+            images = st.session_state.get('input_images')
             personality_text = st.session_state.get('custom_personality', '')
             if st.session_state.get('selected_personality') == 'LLM Generated':
                 if not personality_text:
@@ -827,7 +833,8 @@ class LofnApp:
                         self.temperature,
                         self.model,
                         self.debug,
-                        st.session_state.get('reasoning_level', 'medium')
+                        st.session_state.get('reasoning_level', 'medium'),
+                        input_images=images,
                     )
                     st.session_state['custom_personality'] = personality_text
                 display_temporary_results("Personality", personality_text, expanded=False)
@@ -840,6 +847,7 @@ class LofnApp:
                 reasoning_level=st.session_state.get('reasoning_level', 'medium'),
                 medium="music",
                 personality_prompt=personality_text,
+                input_images=images,
             )
             st.session_state['meta_prompt'] = meta_prompt['meta_prompt']
             panel_text = st.session_state.get('custom_panel', '')
@@ -853,6 +861,7 @@ class LofnApp:
                         self.debug,
                         st.session_state.get('reasoning_level', 'medium'),
                         personality_prompt=personality_text,
+                        input_images=images,
                     )
                     st.session_state['custom_panel'] = panel_text
                 display_temporary_results("Panel Prompt", panel_text, expanded=False)
@@ -864,11 +873,9 @@ class LofnApp:
                 .replace('{genres_list}', genres_list)
                 .replace('{frames_list}', frames_list)
                 .replace('{input}', st.session_state.get('input', ''))
+                .replace('{image_context}', "\n".join(images) if images else "")
             )
             display_temporary_results("Meta Prompt", meta_prompt['meta_prompt'], expanded=False)
-            images = st.session_state.get('input_images')
-            if images:
-                input_text = f"{input_text}\n\nReference Images:\n" + "\n".join(images)
             st.session_state['prompt_input'] = input_text
 
             with st.spinner("Generating music concepts..."):
@@ -1011,6 +1018,7 @@ class LofnApp:
         try:
             st.session_state['video_concept_mediums'] = []
             input_text = st.session_state['input']
+            images = st.session_state.get('input_images')
             if st.session_state.get('competition_mode'):
                 personality_text = st.session_state.get('custom_personality', '')
                 if st.session_state.get('selected_personality') == 'LLM Generated':
@@ -1021,7 +1029,8 @@ class LofnApp:
                             self.temperature,
                             self.model,
                             self.debug,
-                            st.session_state.get('reasoning_level','medium')
+                            st.session_state.get('reasoning_level','medium'),
+                            input_images=images,
                         )
                         st.session_state['custom_personality'] = personality_text
                     display_temporary_results("Personality", personality_text, expanded=False)
@@ -1034,6 +1043,7 @@ class LofnApp:
                     reasoning_level=st.session_state.get('reasoning_level','medium'),
                     medium="video",
                     personality_prompt=personality_text,
+                    input_images=images,
                 )
                 st.session_state['meta_prompt'] = meta_prompt['meta_prompt']
                 panel_text = st.session_state.get('custom_panel', '')
@@ -1047,6 +1057,7 @@ class LofnApp:
                             self.debug,
                             st.session_state.get('reasoning_level','medium'),
                             personality_prompt=personality_text,
+                            input_images=images,
                         )
                         st.session_state['custom_panel'] = panel_text
                     display_temporary_results("Panel Prompt", panel_text, expanded=False)
@@ -1058,11 +1069,12 @@ class LofnApp:
                     .replace('{frames_list}', frames_list)
                     .replace('{film_styles_list}', film_styles_list)
                     .replace('{input}', st.session_state.get('input', ''))
+                    .replace('{image_context}', "\n".join(images) if images else "")
                 )
                 display_temporary_results("Meta Prompt", meta_prompt['meta_prompt'], expanded=False)
-            images = st.session_state.get('input_images')
-            if images:
-                input_text = f"{input_text}\n\nReference Images:\n" + "\n".join(images)
+            else:
+                if images:
+                    input_text = f"{input_text}\n\nReference Images:\n" + "\n".join(images)
             st.session_state['prompt_input'] = input_text
             with st.spinner("Generating video concepts..."):
                 concepts, style_axes, creativity_spectrum = generate_video_concept_mediums(


### PR DESCRIPTION
## Summary
- propagate reference image context through meta, panel, and personality prompt generation
- replace image placeholders in competition overall prompt templates
- pass uploaded images through UI to avoid missing `image_context` errors

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_689e3ec700c4832994b2c8f1c24c663d