### PR TITLE
Add image-to-video personality chat

### DIFF
--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -89,6 +89,7 @@ pair_selection_prompt = read_prompt('/lofn/prompts/pair_selection_prompt.txt')
 panel_generation_prompt = read_prompt('/lofn/prompts/panel_generation_prompt.txt')
 personality_generation_prompt = read_prompt('/lofn/prompts/personality_generation_prompt.txt')
 personality_chat_template = read_prompt('/lofn/prompts/personality_chat_template.txt')
+personality_image2video_template = read_prompt('/lofn/prompts/personality_image2video_template.txt')
 
 # Video prompts
 video_concept_header_part1 = read_prompt('/lofn/prompts/video_concept_header.txt')
@@ -1821,13 +1822,14 @@ def run_personality_chat(
     reasoning_level="medium",
     debug=False,
     input_images: Optional[List[str]] = None,
+    system_prompt: str = personality_chat_template,
 ):
     """Run a free-form chat with a given personality using the COGNITION MATRIX template."""
     llm = get_llm(model, temperature, Config.OPENAI_API, Config.ANTHROPIC_API, debug, reasoning_level)
     readme_path = Path('/workspace/lofn/README.md')
     lofn_readme = readme_path.read_text() if readme_path.exists() else ""
     prompt = ChatPromptTemplate.from_messages([
-        ("system", personality_chat_template),
+        ("system", system_prompt),
         MessagesPlaceholder("chat_history"),
         MessagesPlaceholder("image_context"),
         ("human", "{input}"),
@@ -1859,6 +1861,7 @@ async def stream_personality_chat(
     reasoning_level="medium",
     debug=False,
     input_images: Optional[List[str]] = None,
+    system_prompt: str = personality_chat_template,
 ):
     """Stream a free-form chat response with a given personality.
 
@@ -1881,7 +1884,7 @@ async def stream_personality_chat(
     lofn_readme = readme_path.read_text() if readme_path.exists() else ""
 
     prompt = ChatPromptTemplate.from_messages([
-        ("system", personality_chat_template),
+        ("system", system_prompt),
         MessagesPlaceholder("chat_history"),
         MessagesPlaceholder("image_context"),
         ("human", "{input}"),
@@ -1918,8 +1921,57 @@ async def stream_personality_chat(
             reasoning_level=reasoning_level,
             debug=debug,
             input_images=input_images,
+            system_prompt=system_prompt,
         )
         yield fallback
+
+
+def run_personality_image2video_chat(
+    personality_prompt,
+    chat_history,
+    user_input,
+    model="gpt-3.5-turbo-16k",
+    temperature=0.7,
+    reasoning_level="medium",
+    debug=False,
+    input_images: Optional[List[str]] = None,
+):
+    """Run a chat using the image-to-video personality template."""
+    return run_personality_chat(
+        personality_prompt,
+        chat_history,
+        user_input,
+        model=model,
+        temperature=temperature,
+        reasoning_level=reasoning_level,
+        debug=debug,
+        input_images=input_images,
+        system_prompt=personality_image2video_template,
+    )
+
+
+def stream_personality_image2video_chat(
+    personality_prompt,
+    chat_history,
+    user_input,
+    model="gpt-3.5-turbo-16k",
+    temperature=0.7,
+    reasoning_level="medium",
+    debug=False,
+    input_images: Optional[List[str]] = None,
+):
+    """Stream chat responses using the image-to-video personality template."""
+    return stream_personality_chat(
+        personality_prompt,
+        chat_history,
+        user_input,
+        model=model,
+        temperature=temperature,
+        reasoning_level=reasoning_level,
+        debug=debug,
+        input_images=input_images,
+        system_prompt=personality_image2video_template,
+    )
 
 @st.cache_data(persist=True)
 def select_best_pairs(input_text, pairs, num_best_pairs, max_retries, temperature, model="gpt-3.5-turbo-16k", debug=False, reasoning_level="medium"):

--- a/lofn/ui.py
+++ b/lofn/ui.py
@@ -267,6 +267,7 @@ class LofnApp:
             'Video Generation': 'video',
             'Music Generation': 'music',
             'Personality Chat': 'art',
+            'Image to Video Chat': 'video',
         }
         mode_key = mapping.get(mode_name, 'art')
         defaults = self.model_priority.get(mode_key, {})
@@ -284,6 +285,7 @@ class LofnApp:
             'Video Generation': 'video',
             'Music Generation': 'music',
             'Personality Chat': 'art',
+            'Image to Video Chat': 'video',
         }
         mode_key = mapping.get(mode_name, 'art')
         defaults = self.model_priority.get(mode_key, {})
@@ -308,6 +310,7 @@ class LofnApp:
             "Video Generation",
             "Music Generation",
             "Personality Chat",
+            "Image to Video Chat",
             "Prompt Explorer",
         ]
         current_tab = st.session_state.get('selected_tab', tabs[0])
@@ -327,6 +330,8 @@ class LofnApp:
             self.render_video_generation()
         elif selected_tab == "Music Generation":
             self.render_music_generation()
+        elif selected_tab == "Image to Video Chat":
+            self.render_image_to_video_chat()
         elif selected_tab == "Prompt Explorer":
             self.render_prompt_explorer()
         elif selected_tab == "Personality Chat":
@@ -1589,8 +1594,106 @@ class LofnApp:
                     async_to_sync_generator(response_stream)
                 )
             st.session_state['chat_history'].append(AIMessage(content=response_text))
-            st.session_state['chat_input_images'] = []
-            st.session_state['clear_personality_chat_images'] = True
+        st.session_state['chat_input_images'] = []
+        st.session_state['clear_personality_chat_images'] = True
+
+    def render_image_to_video_chat(self):
+        st.header("Image to Video Chat")
+        personality_names = [p['name'] for p in PERSONALITY_OPTIONS] + ['Custom']
+        st.session_state['image2video_selected_personality'] = st.selectbox(
+            'Personality',
+            personality_names,
+            index=personality_names.index(
+                st.session_state.get('image2video_selected_personality', personality_names[0])
+            ),
+            key='image2video_personality_select',
+        )
+        if st.session_state['image2video_selected_personality'] == 'Custom':
+            st.session_state['image2video_custom_personality'] = st.text_area(
+                'Custom Personality',
+                value=st.session_state.get('image2video_custom_personality', ''),
+                height=150,
+                key='image2video_custom_personality',
+            )
+        else:
+            st.session_state['image2video_custom_personality'] = next(
+                p['prompt']
+                for p in PERSONALITY_OPTIONS
+                if p['name'] == st.session_state['image2video_selected_personality']
+            )
+        personality_text = st.session_state.get('image2video_custom_personality', '')
+
+        if st.session_state.get('clear_image2video_chat_images'):
+            st.session_state.pop('image2video_chat_images', None)
+            st.session_state['clear_image2video_chat_images'] = False
+
+        st.subheader("Reference Images (Optional)")
+        uploaded_files = st.file_uploader(
+            "Upload up to 5 images",
+            type=["png", "jpg", "jpeg"],
+            accept_multiple_files=True,
+            key="image2video_chat_images",
+        )
+        chat_images = []
+        if uploaded_files:
+            if len(uploaded_files) > 5:
+                st.warning("Only the first 5 images will be used.")
+            for file in uploaded_files[:5]:
+                chat_images.append(
+                    f"data:{file.type};base64,{base64.b64encode(file.getvalue()).decode()}"
+                )
+        st.session_state['image2video_chat_input_images'] = chat_images
+
+        if 'image2video_chat_history' not in st.session_state:
+            st.session_state['image2video_chat_history'] = []
+
+        for msg in st.session_state['image2video_chat_history']:
+            role = 'user' if isinstance(msg, HumanMessage) else 'assistant'
+            with st.chat_message(role):
+                if isinstance(msg.content, list):
+                    for part in msg.content:
+                        if part.get("type") == "text":
+                            st.markdown(part.get("text", ""))
+                        elif part.get("type") == "image_url":
+                            st.image(base64.b64decode(part["image_url"]["url"].split(",")[1]))
+                else:
+                    st.markdown(msg.content)
+
+        user_input = st.chat_input("Send a message")
+        if user_input:
+            history = st.session_state['image2video_chat_history'][:]
+            images = st.session_state.get('image2video_chat_input_images', [])
+            user_message = HumanMessage(
+                content=[
+                    {"type": "text", "text": user_input},
+                    *[
+                        {"type": "image_url", "image_url": {"url": img}}
+                        for img in images
+                    ],
+                ]
+            )
+            st.session_state['image2video_chat_history'].append(user_message)
+            with st.chat_message("user"):
+                st.markdown(user_input)
+                for img in images:
+                    st.image(base64.b64decode(img.split(",")[1]))
+            response_stream = stream_personality_image2video_chat(
+                personality_text,
+                history,
+                user_input,
+                model=self.model,
+                temperature=self.temperature,
+                reasoning_level=st.session_state.get('reasoning_level', 'medium'),
+                debug=self.debug,
+                input_images=images,
+            )
+            with st.chat_message("assistant"):
+                response_text = st.write_stream(
+                    async_to_sync_generator(response_stream)
+                )
+            st.session_state['image2video_chat_history'].append(AIMessage(content=response_text))
+            st.session_state['image2video_chat_input_images'] = []
+            st.session_state['clear_image2video_chat_images'] = True
 
     def initialize_session_state(self):
         cm_model, prompt_model = self.get_defaults_for_mode('Image Generation')
@@ -1629,6 +1732,8 @@ class LofnApp:
             'custom_panel': PANEL_OPTIONS[0]['prompt'],
             'selected_personality': PERSONALITY_OPTIONS[0]['name'],
             'custom_personality': PERSONALITY_OPTIONS[0]['prompt'],
+            'image2video_selected_personality': PERSONALITY_OPTIONS[0]['name'],
+            'image2video_custom_personality': PERSONALITY_OPTIONS[0]['prompt'],
             'num_best_pairs': 3,
             'prompt_input': '',
             'creativity_spectrum': None,
@@ -1640,6 +1745,9 @@ class LofnApp:
             'chat_history': [],
             'chat_input_images': [],
             'clear_personality_chat_images': False,
+            'image2video_chat_history': [],
+            'image2video_chat_input_images': [],
+            'clear_image2video_chat_images': False,
         }
 
         for key, value in default_values.items():


### PR DESCRIPTION
## Summary
- Support image-to-video personality chat using new template and run/stream wrappers
- Expose new "Image to Video Chat" tab in UI with image uploads and streaming replies

## Testing
- `python -m py_compile lofn/llm_integration.py lofn/ui.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pip install pyyaml` *(fails: Could not find a version that satisfies the requirement pyyaml)*

------
https://chatgpt.com/codex/tasks/task_e_689e4702b4148329b322d5f3f8d236e1