### PR TITLE
Avoid hashing args_dict in run_chain_with_retries

### DIFF
--- a/lofn/image_generation.py
+++ b/lofn/image_generation.py
@@ -382,15 +382,15 @@ def generate_image_title(input, concept, medium, image, max_retries, temperature
     )
     
     output = run_chain_with_retries(
-        chain, 
-        args_dict={
+        chain,
+        _args_dict={
         "input": input,
         "concept": concept,
         "medium": medium,
         "facets": st.session_state.essence_and_facets_output['essence_and_facets']['facets'],
         "image": image
         },
-        max_retries=max_retries, 
+        max_retries=max_retries,
         debug=debug,
         expected_schema = image_title_schema)
 

--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -740,7 +740,7 @@ def run_llm_chain(chains, chain_name, args_dict, max_retries, model=None,
                   debug=None, expected_schema=None):
     chain = chains[chain_name]
     output = run_chain_with_retries(
-        chain, max_retries=max_retries, args_dict=args_dict, is_correction=False,
+        chain, max_retries=max_retries, _args_dict=args_dict, is_correction=False,
         model=model, debug=debug, expected_schema=expected_schema
     )
 
@@ -752,7 +752,7 @@ def run_llm_chain(chains, chain_name, args_dict, max_retries, model=None,
 
 @st.cache_data(persist=True)
 def run_chain_with_retries(
-    _lang_chain, max_retries, args_dict=None, is_correction=False, model=None,
+    _lang_chain, max_retries, _args_dict=None, is_correction=False, model=None,
     debug=False, expected_schema=None
 ):
     output = None
@@ -760,9 +760,9 @@ def run_chain_with_retries(
     while retry_count < max_retries:
         try:
             output = run_any_chain(
-                _lang_chain, args_dict, is_correction, retry_count, model, debug, expected_schema
+                _lang_chain, _args_dict, is_correction, retry_count, model, debug, expected_schema
             )
-            args_dict['output'] = output
+            _args_dict['output'] = output
             if debug:
                 st.write(f"Raw output from LLM:\n{output}")
 
@@ -1577,7 +1577,7 @@ def generate_simple_music_prompts(
     
         output_essence = run_chain_with_retries(
             chain,
-            args_dict={"input": input_text},
+            _args_dict={"input": input_text},
             max_retries=max_retries,
             model=model,
             debug=debug,
@@ -1602,10 +1602,10 @@ def generate_simple_music_prompts(
         # Run the chain with retries
         parsed_output = run_chain_with_retries(
             gen_chain,
-            args_dict={
-                "input": input_text, 
-                "essence":output_essence["essence_and_facets"]["essence"], 
-                "facets":output_essence["essence_and_facets"]["facets"], 
+            _args_dict={
+                "input": input_text,
+                "essence":output_essence["essence_and_facets"]["essence"],
+                "facets":output_essence["essence_and_facets"]["facets"],
                 "style_axes":output_essence["essence_and_facets"]["style_axes"]},
             max_retries=max_retries,
             model=model,

--- a/lofn/prompts/personality_generation_prompt.txt
+++ b/lofn/prompts/personality_generation_prompt.txt
@@ -349,7 +349,7 @@ SECTION D — EXAMPLE OUTPUTS (return at least this level of detail)
     ]) | llm
 
     output_essence = run_chain_with_retries(
-        chain, args_dict={{"input": input_text}},
+        chain, _args_dict={{"input": input_text}},
         max_retries=max_retries, model=model,
         expected_schema=music_facets_schema
     )
@@ -361,7 +361,7 @@ SECTION D — EXAMPLE OUTPUTS (return at least this level of detail)
 
     parsed_output = run_chain_with_retries(
         gen_chain,
-        args_dict={{
+        _args_dict={{
             "input": input_text,
             "essence": output_essence["essence_and_facets"]["essence"],
             "facets": output_essence["essence_and_facets"]["facets"],


### PR DESCRIPTION
## Summary
- Prevent Streamlit caching errors by renaming `args_dict` to `_args_dict` in `run_chain_with_retries`.
- Update all call sites, including music prompt and image title generators, to use the new argument name.
- Sync personality prompt template with the updated parameter.

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pip install pyyaml` *(failed: Could not connect to proxy / no matching distribution)*


------
https://chatgpt.com/codex/tasks/task_e_689e4c74e1c8832990a9e3db22c498dc