### PR TITLE
Resize uploaded images and fix personality chat image handling

### DIFF
--- a/lofn/helpers.py
+++ b/lofn/helpers.py
@@ -2,6 +2,9 @@
 
 import re
 import json
+import base64
+from io import BytesIO
+from PIL import Image
 import streamlit as st
 import requests
 import random
@@ -28,6 +31,25 @@ def set_style_axes(auto_style: bool, style_axes=None):
 def read_prompt(file_path):
     with open(file_path, "r") as file:
         return file.read()
+
+
+def resize_image_to_data_url(uploaded_file, target: int = 512) -> str:
+    """Return a data URL for ``uploaded_file`` scaled so the smallest axis is ``target`` pixels."""
+    image = Image.open(BytesIO(uploaded_file.getvalue()))
+    width, height = image.size
+    if min(width, height) == 0:
+        encoded = base64.b64encode(uploaded_file.getvalue()).decode()
+        return f"data:{uploaded_file.type};base64,{encoded}"
+    scale = target / min(width, height)
+    new_size = (int(width * scale), int(height * scale))
+    image = image.resize(new_size, Image.LANCZOS)
+    buffer = BytesIO()
+    fmt = "PNG" if uploaded_file.type == "image/png" else "JPEG"
+    if fmt == "JPEG":
+        image = image.convert("RGB")
+    image.save(buffer, format=fmt)
+    encoded = base64.b64encode(buffer.getvalue()).decode()
+    return f"data:{uploaded_file.type};base64,{encoded}"
 
 
 def sample_artistic_frames(min_count: int = 40, max_count: int = 50) -> str:

--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -17,7 +17,7 @@ from langchain_anthropic.experimental import ChatAnthropicTools
 from langchain.output_parsers import ResponseSchema, StructuredOutputParser
 from langchain.schema import OutputParserException
 from langchain.callbacks import AsyncIteratorCallbackHandler
-from langchain.schema import HumanMessage
+from langchain.schema import HumanMessage, SystemMessage
 from langchain_core.callbacks.manager import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
 from typing import Any, Dict, List, Optional
@@ -1825,26 +1825,29 @@ def run_personality_chat(
     system_prompt: str = personality_chat_template,
 ):
     """Run a free-form chat with a given personality using the COGNITION MATRIX template."""
-    llm = get_llm(model, temperature, Config.OPENAI_API, Config.ANTHROPIC_API, debug, reasoning_level)
+    llm = get_llm(
+        model, temperature, Config.OPENAI_API, Config.ANTHROPIC_API, debug, reasoning_level
+    )
     readme_path = Path('/workspace/lofn/README.md')
     lofn_readme = readme_path.read_text() if readme_path.exists() else ""
-    prompt = ChatPromptTemplate.from_messages([
-        ("system", system_prompt),
-        MessagesPlaceholder("chat_history"),
-        MessagesPlaceholder("image_context"),
-        ("human", "{input}"),
-    ])
-    image_context = prepare_image_messages(input_images)
-    chain = prompt | llm
-    response = chain.invoke(
-        {
-            "personality": personality_prompt,
-            "lofn_readme": lofn_readme,
-            "chat_history": chat_history,
-            "image_context": image_context,
-            "input": user_input,
-        }
+    system_text = system_prompt.replace("{personality}", personality_prompt).replace(
+        "{lofn_readme}", lofn_readme
     )
+    user_message = HumanMessage(
+        content=[
+            {"type": "text", "text": user_input},
+            *[
+                {"type": "image_url", "image_url": {"url": img}}
+                for img in (input_images or [])
+            ],
+        ]
+    )
+    prompt = ChatPromptTemplate.from_messages([
+        SystemMessage(content=system_text),
+        MessagesPlaceholder("chat_history"),
+    ])
+    chain = prompt | llm
+    response = chain.invoke({"chat_history": chat_history + [user_message]})
     if isinstance(response, dict):
         return response.get("text", str(response))
     if hasattr(response, "content"):
@@ -1872,34 +1875,30 @@ async def stream_personality_chat(
 
     # Build the chain using the same prompt setup as the non-streaming version
     llm = get_llm(
-        model,
-        temperature,
-        Config.OPENAI_API,
-        Config.ANTHROPIC_API,
-        debug,
-        reasoning_level,
+        model, temperature, Config.OPENAI_API, Config.ANTHROPIC_API, debug, reasoning_level
     )
 
     readme_path = Path('/workspace/lofn/README.md')
     lofn_readme = readme_path.read_text() if readme_path.exists() else ""
-
+    system_text = system_prompt.replace("{personality}", personality_prompt).replace(
+        "{lofn_readme}", lofn_readme
+    )
+    user_message = HumanMessage(
+        content=[
+            {"type": "text", "text": user_input},
+            *[
+                {"type": "image_url", "image_url": {"url": img}}
+                for img in (input_images or [])
+            ],
+        ]
+    )
     prompt = ChatPromptTemplate.from_messages([
-        ("system", system_prompt),
+        SystemMessage(content=system_text),
         MessagesPlaceholder("chat_history"),
-        MessagesPlaceholder("image_context"),
-        ("human", "{input}"),
     ])
 
-    image_context = prepare_image_messages(input_images)
-
     chain = prompt | llm
-    inputs = {
-        "personality": personality_prompt,
-        "lofn_readme": lofn_readme,
-        "chat_history": chat_history,
-        "image_context": image_context,
-        "input": user_input,
-    }
+    inputs = {"chat_history": chat_history + [user_message]}
 
     callback = AsyncIteratorCallbackHandler()
 

--- a/lofn/ui.py
+++ b/lofn/ui.py
@@ -560,9 +560,7 @@ class LofnApp:
             if len(uploaded_files) > 5:
                 st.warning("Only the first 5 images will be used.")
             for file in uploaded_files[:5]:
-                images.append(
-                    f"data:{file.type};base64,{base64.b64encode(file.getvalue()).decode()}"
-                )
+                images.append(resize_image_to_data_url(file))
         st.session_state['input_images'] = images
 
         # If there's no user input, provide a tip
@@ -987,9 +985,7 @@ class LofnApp:
             if len(uploaded_files) > 5:
                 st.warning("Only the first 5 images will be used.")
             for file in uploaded_files[:5]:
-                images.append(
-                    f"data:{file.type};base64,{base64.b64encode(file.getvalue()).decode()}"
-                )
+                images.append(resize_image_to_data_url(file))
         st.session_state['input_images'] = images
         if not st.session_state['input']:
             st.info("Tip: Describe a scene or narrative you'd like to see in motion.")
@@ -1272,9 +1268,7 @@ class LofnApp:
             if len(uploaded_files) > 5:
                 st.warning("Only the first 5 images will be used.")
             for file in uploaded_files[:5]:
-                images.append(
-                    f"data:{file.type};base64,{base64.b64encode(file.getvalue()).decode()}"
-                )
+                images.append(resize_image_to_data_url(file))
         st.session_state['input_images'] = images
         if not st.session_state['input']:
             st.info("Tip: Include themes, emotions, specific elements, and desired run time length.")
@@ -1541,9 +1535,7 @@ class LofnApp:
             if len(uploaded_files) > 5:
                 st.warning("Only the first 5 images will be used.")
             for file in uploaded_files[:5]:
-                chat_images.append(
-                    f"data:{file.type};base64,{base64.b64encode(file.getvalue()).decode()}"
-                )
+                chat_images.append(resize_image_to_data_url(file))
         st.session_state['chat_input_images'] = chat_images
 
         if 'chat_history' not in st.session_state:
@@ -1639,9 +1631,7 @@ class LofnApp:
             if len(uploaded_files) > 5:
                 st.warning("Only the first 5 images will be used.")
             for file in uploaded_files[:5]:
-                chat_images.append(
-                    f"data:{file.type};base64,{base64.b64encode(file.getvalue()).decode()}"
-                )
+                chat_images.append(resize_image_to_data_url(file))
         st.session_state['image2video_chat_input_images'] = chat_images
 
         if 'image2video_chat_history' not in st.session_state:


### PR DESCRIPTION
## Summary
- Resize uploaded images to 512px minimum axis before sending to models
- Ensure personality chat bundles user images with text and tolerate complex system prompts
- Add image resizing helper and update prompts to avoid unescaped braces

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_689e5138c54c8329bb3982d28ff2466b