### PR TITLE
Use content IDs for image attachments

### DIFF
--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -40,6 +40,7 @@ import random
 import numpy as np
 import pandas as pd
 import logging
+import base64
 from helpers import display_temporary_results, display_temporary_results_no_expander
 from langchain_core.callbacks.manager import CallbackManagerForLLMRun
 import openai  # For the advanced "o1" usage if needed
@@ -54,15 +55,39 @@ class LofnError(Exception):
 logger = logging.getLogger(__name__)
 
 def prepare_image_messages(image_strings: List[str]) -> List[HumanMessage]:
-    """Convert data URL strings to LangChain HumanMessage objects.
+    """Convert data URLs to messages with binary attachments.
 
-    Only the first 5 images are used.
+    Only the first five images are included.  Each image is attached using a
+    content ID (``cid``) so the raw bytes do not inflate the token count.
     """
     image_strings = image_strings[:5] if image_strings else []
-    return [
-        HumanMessage(content=[{"type": "image_url", "image_url": {"url": img}}])
-        for img in image_strings
-    ]
+    messages: List[HumanMessage] = []
+    for idx, img in enumerate(image_strings):
+        if img.startswith("data:"):
+            header, b64_data = img.split(",", 1)
+            mime = header.split(";")[0].split(":")[1]
+            data = base64.b64decode(b64_data)
+            messages.append(
+                HumanMessage(
+                    content=[{"type": "input_image", "image_url": {"url": f"cid:image{idx}"}}],
+                    additional_kwargs={
+                        "attachments": [
+                            {
+                                "name": f"image{idx}",
+                                "data": data,
+                                "mime_type": mime,
+                            }
+                        ]
+                    },
+                )
+            )
+        else:
+            messages.append(
+                HumanMessage(
+                    content=[{"type": "input_image", "image_url": {"url": img}}]
+                )
+            )
+    return messages
 
 # Load prompts
 concept_system = read_prompt('/lofn/prompts/concept_system.txt')

--- a/tests/test_image_inputs.py
+++ b/tests/test_image_inputs.py
@@ -10,10 +10,11 @@ module_ast = ast.Module(body=[func_node], type_ignores=[])
 code = compile(module_ast, filename="<prepare_image_messages>", mode="exec")
 
 class HumanMessage:
-    def __init__(self, content):
+    def __init__(self, content, additional_kwargs=None):
         self.content = content
+        self.additional_kwargs = additional_kwargs or {}
 
-ns = {'HumanMessage': HumanMessage, 'List': list}
+ns = {'HumanMessage': HumanMessage, 'List': list, 'base64': base64}
 exec(code, ns)
 prepare_image_messages = ns['prepare_image_messages']
 
@@ -23,5 +24,9 @@ def test_prepare_image_messages_limit():
     images = [f"data:image/png;base64,{dummy}" for _ in range(6)]
     msgs = prepare_image_messages(images)
     assert len(msgs) == 5
-    for m in msgs:
-        assert m.content[0]["type"] == "image_url"
+    for idx, m in enumerate(msgs):
+        assert m.content[0]["type"] == "input_image"
+        assert m.content[0]["image_url"]["url"] == f"cid:image{idx}"
+        attachments = m.additional_kwargs["attachments"]
+        assert attachments[0]["name"] == f"image{idx}"
+        assert isinstance(attachments[0]["data"], bytes)


### PR DESCRIPTION
## Summary
- send images to LLMs as CID-referenced attachments instead of large data URLs
- update tests for new input image handling with attachments

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e5473dbdc8329a80faebdb345966c