### PR TITLE
JPEG compress images before LLM calls

### DIFF
--- a/lofn/helpers.py
+++ b/lofn/helpers.py
@@ -13,10 +13,13 @@ import csv
 import asyncio
 import threading
 from queue import Queue
-from typing import Union, List, AsyncGenerator, Generator
+from typing import Union, List, AsyncGenerator, Generator, Tuple, Optional
 from datetime import datetime
 import os
-from config import Config
+try:
+    from config import Config
+except ModuleNotFoundError:  # pragma: no cover - fallback for package import
+    from .config import Config
 import plotly.graph_objects as go
 
 def set_style_axes(auto_style: bool, style_axes=None):
@@ -32,24 +35,27 @@ def read_prompt(file_path):
     with open(file_path, "r") as file:
         return file.read()
 
+def compress_image_bytes(data: bytes, max_dim: int = 1024, quality: int = 80) -> Tuple[bytes, Optional[str]]:
+    """Return JPEG-compressed ``data`` and its MIME type.
 
-def resize_image_to_data_url(uploaded_file, target: int = 512) -> str:
-    """Return a data URL for ``uploaded_file`` scaled so the smallest axis is ``target`` pixels."""
-    image = Image.open(BytesIO(uploaded_file.getvalue()))
-    width, height = image.size
-    if min(width, height) == 0:
-        encoded = base64.b64encode(uploaded_file.getvalue()).decode()
-        return f"data:{uploaded_file.type};base64,{encoded}"
-    scale = target / min(width, height)
-    new_size = (int(width * scale), int(height * scale))
-    image = image.resize(new_size, Image.LANCZOS)
+    If ``data`` is not a valid image, return it unchanged and ``None`` as the MIME type.
+    """
+    try:
+        img = Image.open(BytesIO(data))
+    except Exception:
+        return data, None
+
+    img.thumbnail((max_dim, max_dim), Image.LANCZOS)
     buffer = BytesIO()
-    fmt = "PNG" if uploaded_file.type == "image/png" else "JPEG"
-    if fmt == "JPEG":
-        image = image.convert("RGB")
-    image.save(buffer, format=fmt)
-    encoded = base64.b64encode(buffer.getvalue()).decode()
-    return f"data:{uploaded_file.type};base64,{encoded}"
+    img.convert("RGB").save(buffer, format="JPEG", quality=quality, optimize=True)
+    return buffer.getvalue(), "image/jpeg"
+
+
+def resize_image_to_data_url(uploaded_file, max_dim: int = 1024, quality: int = 80) -> str:
+    """Return a JPEG data URL for ``uploaded_file`` scaled to ``max_dim`` on its largest side."""
+    data, _ = compress_image_bytes(uploaded_file.getvalue(), max_dim=max_dim, quality=quality)
+    encoded = base64.b64encode(data).decode()
+    return f"data:image/jpeg;base64,{encoded}"
 
 
 def sample_artistic_frames(min_count: int = 40, max_count: int = 50) -> str:

--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -34,6 +34,7 @@ from helpers import (
     sample_music_genres,
     sample_art_styles,
     sample_film_styles,
+    compress_image_bytes,
 )
 import plotly.graph_objects as go
 import random
@@ -65,8 +66,10 @@ def prepare_image_messages(image_strings: List[str]) -> List[HumanMessage]:
     for idx, img in enumerate(image_strings):
         if img.startswith("data:"):
             header, b64_data = img.split(",", 1)
-            mime = header.split(";")[0].split(":")[1]
             data = base64.b64decode(b64_data)
+            data, mime = compress_image_bytes(data)
+            if mime is None:
+                mime = header.split(";")[0].split(":")[1]
             messages.append(
                 HumanMessage(
                     content=[{"type": "input_image", "image_url": {"url": f"cid:image{idx}"}}],

--- a/tests/test_image_compression.py
+++ b/tests/test_image_compression.py
@@ -1,0 +1,31 @@
+from io import BytesIO
+from PIL import Image
+import base64
+
+from lofn.helpers import resize_image_to_data_url
+
+
+class DummyUpload:
+    def __init__(self, data: bytes, mime: str = "image/png"):
+        self._data = data
+        self.type = mime
+
+    def getvalue(self) -> bytes:
+        return self._data
+
+
+def test_resize_image_to_data_url_limits_size_and_format():
+    # Create a large red PNG image
+    img = Image.new("RGB", (2000, 1500), color="red")
+    buf = BytesIO()
+    img.save(buf, format="PNG")
+    uploaded = DummyUpload(buf.getvalue())
+
+    data_url = resize_image_to_data_url(uploaded)
+    header, b64_data = data_url.split(",", 1)
+    assert header == "data:image/jpeg;base64"
+
+    data = base64.b64decode(b64_data)
+    out_img = Image.open(BytesIO(data))
+    assert max(out_img.size) == 1024
+    assert out_img.format == "JPEG"

--- a/tests/test_image_inputs.py
+++ b/tests/test_image_inputs.py
@@ -15,6 +15,9 @@ class HumanMessage:
         self.additional_kwargs = additional_kwargs or {}
 
 ns = {'HumanMessage': HumanMessage, 'List': list, 'base64': base64}
+# Inject helper used by prepare_image_messages
+from lofn.helpers import compress_image_bytes
+ns['compress_image_bytes'] = compress_image_bytes
 exec(code, ns)
 prepare_image_messages = ns['prepare_image_messages']
 


### PR DESCRIPTION
## Summary
- Add `compress_image_bytes` to downscale images to 1024px max and save as JPEG
- Use compressed bytes in `prepare_image_messages` and simplify `resize_image_to_data_url`
- Introduce tests confirming compression behavior and wire helper into existing tests

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e5b577d108329a96b4909b53fc35d