### PR TITLE
Send inline JPEG image payloads for all generation and chat flows

### DIFF
--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -21,31 +21,62 @@ from langchain.schema import HumanMessage, SystemMessage
 from langchain_core.callbacks.manager import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
 from typing import Any, Dict, List, Optional
-from config import Config
-from helpers import (
-    read_prompt,
-    send_to_discord,
-    parse_output,
-    display_facets,
-    display_creativity_and_style_axes,
-    sample_artistic_frames,
-    sample_video_frames,
-    sample_music_frames,
-    sample_music_genres,
-    sample_art_styles,
-    sample_film_styles,
-    compress_image_bytes,
-)
+try:
+    from config import Config
+except ModuleNotFoundError:  # pragma: no cover - fallback for package import
+    from .config import Config
+try:
+    from helpers import (
+        read_prompt,
+        send_to_discord,
+        parse_output,
+        display_facets,
+        display_creativity_and_style_axes,
+        sample_artistic_frames,
+        sample_video_frames,
+        sample_music_frames,
+        sample_music_genres,
+        sample_art_styles,
+        sample_film_styles,
+        compress_image_bytes,
+    )
+except ModuleNotFoundError:  # pragma: no cover - fallback for package import
+    from .helpers import (
+        read_prompt,
+        send_to_discord,
+        parse_output,
+        display_facets,
+        display_creativity_and_style_axes,
+        sample_artistic_frames,
+        sample_video_frames,
+        sample_music_frames,
+        sample_music_genres,
+        sample_art_styles,
+        sample_film_styles,
+        compress_image_bytes,
+    )
 import plotly.graph_objects as go
 import random
 import numpy as np
 import pandas as pd
 import logging
 import base64
-from helpers import display_temporary_results, display_temporary_results_no_expander
+try:
+    from helpers import (
+        display_temporary_results,
+        display_temporary_results_no_expander,
+    )
+except ModuleNotFoundError:  # pragma: no cover - fallback for package import
+    from .helpers import (
+        display_temporary_results,
+        display_temporary_results_no_expander,
+    )
 from langchain_core.callbacks.manager import CallbackManagerForLLMRun
 import openai  # For the advanced "o1" usage if needed
-from o1_integration import *
+try:
+    from o1_integration import *  # noqa: F401,F403
+except ModuleNotFoundError:  # pragma: no cover - fallback for package import
+    from .o1_integration import *  # noqa: F401,F403
 from pathlib import Path
 
 class LofnError(Exception):
@@ -56,40 +87,45 @@ class LofnError(Exception):
 logger = logging.getLogger(__name__)
 
 def prepare_image_messages(image_strings: List[str]) -> List[HumanMessage]:
-    """Convert data URLs to messages with binary attachments.
+    """Return ``HumanMessage`` objects with inline JPEG data URLs.
 
-    Only the first five images are included.  Each image is attached using a
-    content ID (``cid``) so the raw bytes do not inflate the token count.
+    The OpenAI image spec expects images to be sent directly within the
+    payload.  To ensure compatibility across providers, this function compresses
+    each image to JPEG (max dimension 1024) and embeds it in the message using a
+    ``data:`` URL.  Only the first five images are included.
     """
+
     image_strings = image_strings[:5] if image_strings else []
     messages: List[HumanMessage] = []
-    for idx, img in enumerate(image_strings):
-        if img.startswith("data:"):
-            header, b64_data = img.split(",", 1)
-            data = base64.b64decode(b64_data)
-            data, mime = compress_image_bytes(data)
-            if mime is None:
-                mime = header.split(";")[0].split(":")[1]
-            messages.append(
-                HumanMessage(
-                    content=[{"type": "input_image", "image_url": {"url": f"cid:image{idx}"}}],
-                    additional_kwargs={
-                        "attachments": [
-                            {
-                                "name": f"image{idx}",
-                                "data": data,
-                                "mime_type": mime,
-                            }
-                        ]
-                    },
-                )
+
+    for img in image_strings:
+        url = img
+
+        try:
+            if img.startswith("data:"):
+                header, b64_data = img.split(",", 1)
+                data = base64.b64decode(b64_data)
+                data, mime = compress_image_bytes(data)
+                if mime is None:
+                    mime = header.split(";")[0].split(":")[1]
+            else:
+                response = requests.get(img, timeout=5)
+                response.raise_for_status()
+                data, mime = compress_image_bytes(response.content)
+                if mime is None:
+                    mime = response.headers.get("Content-Type", "image/jpeg")
+            encoded = base64.b64encode(data).decode()
+            url = f"data:{mime};base64,{encoded}"
+        except Exception:
+            # Fallback to original URL if fetching/compression fails
+            pass
+
+        messages.append(
+            HumanMessage(
+                content=[{"type": "input_image", "image_url": {"url": url}}]
             )
-        else:
-            messages.append(
-                HumanMessage(
-                    content=[{"type": "input_image", "image_url": {"url": img}}]
-                )
-            )
+        )
+
     return messages
 
 # Load prompts
@@ -1865,7 +1901,7 @@ def run_personality_chat(
         content=[
             {"type": "text", "text": user_input},
             *[
-                {"type": "image_url", "image_url": {"url": img}}
+                {"type": "input_image", "image_url": {"url": img}}
                 for img in (input_images or [])
             ],
         ]
@@ -1915,7 +1951,7 @@ async def stream_personality_chat(
         content=[
             {"type": "text", "text": user_input},
             *[
-                {"type": "image_url", "image_url": {"url": img}}
+                {"type": "input_image", "image_url": {"url": img}}
                 for img in (input_images or [])
             ],
         ]

--- a/lofn/ui.py
+++ b/lofn/ui.py
@@ -1548,8 +1548,12 @@ class LofnApp:
                     for part in msg.content:
                         if part.get("type") == "text":
                             st.markdown(part.get("text", ""))
-                        elif part.get("type") == "image_url":
-                            st.image(base64.b64decode(part["image_url"]["url"].split(",")[1]))
+                        elif part.get("type") in ("image_url", "input_image"):
+                            url = part.get("image_url", {}).get("url", "")
+                            if url.startswith("data:"):
+                                st.image(base64.b64decode(url.split(",")[1]))
+                            else:
+                                st.image(url)
                 else:
                     st.markdown(msg.content)
 
@@ -1561,7 +1565,7 @@ class LofnApp:
                 content=[
                     {"type": "text", "text": user_input},
                     *[
-                        {"type": "image_url", "image_url": {"url": img}}
+                        {"type": "input_image", "image_url": {"url": img}}
                         for img in images
                     ],
                 ]
@@ -1644,8 +1648,12 @@ class LofnApp:
                     for part in msg.content:
                         if part.get("type") == "text":
                             st.markdown(part.get("text", ""))
-                        elif part.get("type") == "image_url":
-                            st.image(base64.b64decode(part["image_url"]["url"].split(",")[1]))
+                        elif part.get("type") in ("image_url", "input_image"):
+                            url = part.get("image_url", {}).get("url", "")
+                            if url.startswith("data:"):
+                                st.image(base64.b64decode(url.split(",")[1]))
+                            else:
+                                st.image(url)
                 else:
                     st.markdown(msg.content)
 
@@ -1657,7 +1665,7 @@ class LofnApp:
                 content=[
                     {"type": "text", "text": user_input},
                     *[
-                        {"type": "image_url", "image_url": {"url": img}}
+                        {"type": "input_image", "image_url": {"url": img}}
                         for img in images
                     ],
                 ]

--- a/tests/test_prepare_image_messages.py
+++ b/tests/test_prepare_image_messages.py
@@ -1,0 +1,34 @@
+from io import BytesIO
+from PIL import Image
+import base64
+import os
+from pathlib import Path
+
+# ``llm_integration`` expects prompts under ``/lofn/prompts``. Ensure the path
+# exists during testing so the module can import successfully.
+prompts_src = Path(__file__).resolve().parent.parent / "lofn" / "prompts"
+if not Path("/lofn/prompts").exists():
+    os.makedirs("/lofn", exist_ok=True)
+    os.symlink(prompts_src, "/lofn/prompts")
+
+from lofn.llm_integration import prepare_image_messages
+
+
+def make_data_url():
+    img = Image.new("RGB", (100, 100), color="blue")
+    buf = BytesIO()
+    img.save(buf, format="PNG")
+    b64 = base64.b64encode(buf.getvalue()).decode()
+    return f"data:image/png;base64,{b64}"
+
+
+def test_prepare_image_messages_inlines_jpeg():
+    data_url = make_data_url()
+    msgs = prepare_image_messages([data_url])
+    assert len(msgs) == 1
+    msg = msgs[0]
+    assert isinstance(msg.content, list)
+    assert msg.content[0]["type"] == "input_image"
+    url = msg.content[0]["image_url"]["url"]
+    assert url.startswith("data:image/jpeg;base64")
+    assert msg.additional_kwargs == {}


### PR DESCRIPTION
## Summary
- Inline-compress images to JPEG data URLs before sending to the LLM
- Use `input_image` content for personality and image2video chats and handle display in the UI
- Test helper to ensure prepared image messages embed JPEG data

## Testing
- `PYTHONPATH=. pytest tests/test_prepare_image_messages.py tests/test_image_compression.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689e642ecb64832997c25718757d0e33