### PR TITLE
Fix image uploads for chat modes

### DIFF
--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -121,9 +121,7 @@ def prepare_image_messages(image_strings: List[str]) -> List[HumanMessage]:
             pass
 
         messages.append(
-            HumanMessage(
-                content=[{"type": "input_image", "image_url": {"url": url}}]
-            )
+            HumanMessage(content=[{"type": "input_image", "image_url": url}])
         )
 
     return messages
@@ -1901,7 +1899,7 @@ def run_personality_chat(
         content=[
             {"type": "text", "text": user_input},
             *[
-                {"type": "input_image", "image_url": {"url": img}}
+                {"type": "input_image", "image_url": img}
                 for img in (input_images or [])
             ],
         ]
@@ -1951,7 +1949,7 @@ async def stream_personality_chat(
         content=[
             {"type": "text", "text": user_input},
             *[
-                {"type": "input_image", "image_url": {"url": img}}
+                {"type": "input_image", "image_url": img}
                 for img in (input_images or [])
             ],
         ]

--- a/lofn/ui.py
+++ b/lofn/ui.py
@@ -1549,7 +1549,9 @@ class LofnApp:
                         if part.get("type") == "text":
                             st.markdown(part.get("text", ""))
                         elif part.get("type") in ("image_url", "input_image"):
-                            url = part.get("image_url", {}).get("url", "")
+                            url = part.get("image_url", "")
+                            if isinstance(url, dict):
+                                url = url.get("url", "")
                             if url.startswith("data:"):
                                 st.image(base64.b64decode(url.split(",")[1]))
                             else:
@@ -1565,7 +1567,7 @@ class LofnApp:
                 content=[
                     {"type": "text", "text": user_input},
                     *[
-                        {"type": "input_image", "image_url": {"url": img}}
+                        {"type": "input_image", "image_url": img}
                         for img in images
                     ],
                 ]
@@ -1649,7 +1651,9 @@ class LofnApp:
                         if part.get("type") == "text":
                             st.markdown(part.get("text", ""))
                         elif part.get("type") in ("image_url", "input_image"):
-                            url = part.get("image_url", {}).get("url", "")
+                            url = part.get("image_url", "")
+                            if isinstance(url, dict):
+                                url = url.get("url", "")
                             if url.startswith("data:"):
                                 st.image(base64.b64decode(url.split(",")[1]))
                             else:
@@ -1665,7 +1669,7 @@ class LofnApp:
                 content=[
                     {"type": "text", "text": user_input},
                     *[
-                        {"type": "input_image", "image_url": {"url": img}}
+                        {"type": "input_image", "image_url": img}
                         for img in images
                     ],
                 ]

--- a/tests/test_image_inputs.py
+++ b/tests/test_image_inputs.py
@@ -27,9 +27,7 @@ def test_prepare_image_messages_limit():
     images = [f"data:image/png;base64,{dummy}" for _ in range(6)]
     msgs = prepare_image_messages(images)
     assert len(msgs) == 5
-    for idx, m in enumerate(msgs):
+    for m in msgs:
         assert m.content[0]["type"] == "input_image"
-        assert m.content[0]["image_url"]["url"] == f"cid:image{idx}"
-        attachments = m.additional_kwargs["attachments"]
-        assert attachments[0]["name"] == f"image{idx}"
-        assert isinstance(attachments[0]["data"], bytes)
+        assert m.content[0]["image_url"].startswith("data:image/")
+        assert m.additional_kwargs == {}

--- a/tests/test_prepare_image_messages.py
+++ b/tests/test_prepare_image_messages.py
@@ -11,7 +11,28 @@ if not Path("/lofn/prompts").exists():
     os.makedirs("/lofn", exist_ok=True)
     os.symlink(prompts_src, "/lofn/prompts")
 
-from lofn.llm_integration import prepare_image_messages
+# Load only the prepare_image_messages function to avoid heavy imports
+import ast
+from pathlib import Path
+
+source = Path('lofn/llm_integration.py').read_text()
+module = ast.parse(source)
+func_node = next(
+    node for node in module.body if isinstance(node, ast.FunctionDef) and node.name == 'prepare_image_messages'
+)
+module_ast = ast.Module(body=[func_node], type_ignores=[])
+code = compile(module_ast, filename='<prepare_image_messages>', mode='exec')
+
+class HumanMessage:
+    def __init__(self, content, additional_kwargs=None):
+        self.content = content
+        self.additional_kwargs = additional_kwargs or {}
+
+ns = {'HumanMessage': HumanMessage, 'List': list, 'base64': base64}
+from lofn.helpers import compress_image_bytes
+ns['compress_image_bytes'] = compress_image_bytes
+exec(code, ns)
+prepare_image_messages = ns['prepare_image_messages']
 
 
 def make_data_url():
@@ -29,6 +50,6 @@ def test_prepare_image_messages_inlines_jpeg():
     msg = msgs[0]
     assert isinstance(msg.content, list)
     assert msg.content[0]["type"] == "input_image"
-    url = msg.content[0]["image_url"]["url"]
+    url = msg.content[0]["image_url"]
     assert url.startswith("data:image/jpeg;base64")
     assert msg.additional_kwargs == {}


### PR DESCRIPTION
## Summary
- send uploaded images as data URLs in chat messages
- handle new image_url structure in Personality and Image2Video chat UI
- update tests for revised image handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e6a0076a483299489b805085ea65f