### PR TITLE
Fix Streamlit cache hashing for LLM args

### DIFF
--- a/lofn/image_generation.py
+++ b/lofn/image_generation.py
@@ -9,12 +9,10 @@ import fal_client
 import os
 import time
 import asyncio
-import streamlit as st
 from config import Config
 from helpers import *
 import logging
 logger = logging.getLogger(__name__)
-from config import Config
 import plotly.graph_objects as go
 import pandas as pd
 from llm_integration import *
@@ -30,6 +28,7 @@ from langchain.callbacks import AsyncIteratorCallbackHandler
 from langchain.schema import HumanMessage
 from langchain_core.callbacks.manager import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
+import json
 
 import vertexai
 from vertexai.preview.vision_models import ImageGenerationModel
@@ -383,13 +382,13 @@ def generate_image_title(input, concept, medium, image, max_retries, temperature
     
     output = run_chain_with_retries(
         chain,
-        _args_dict={
+        args_json=json.dumps({
         "input": input,
         "concept": concept,
         "medium": medium,
         "facets": st.session_state.essence_and_facets_output['essence_and_facets']['facets'],
         "image": image
-        },
+        }, sort_keys=True),
         max_retries=max_retries,
         debug=debug,
         expected_schema = image_title_schema)

--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -801,8 +801,9 @@ def get_llm(model, temperature, OPENAI_API=None, ANTHROPIC_API=None, debug=False
 def run_llm_chain(chains, chain_name, args_dict, max_retries, model=None,
                   debug=None, expected_schema=None):
     chain = chains[chain_name]
+    args_json = json.dumps(args_dict, sort_keys=True) if args_dict is not None else None
     output = run_chain_with_retries(
-        chain, max_retries=max_retries, args_dict=args_dict, is_correction=False,
+        chain, max_retries=max_retries, args_json=args_json, is_correction=False,
         model=model, debug=debug, expected_schema=expected_schema
     )
 
@@ -814,9 +815,10 @@ def run_llm_chain(chains, chain_name, args_dict, max_retries, model=None,
 
 @st.cache_data(persist=True)
 def run_chain_with_retries(
-    _lang_chain, max_retries, args_dict=None, is_correction=False, model=None,
+    _lang_chain, max_retries, args_json=None, is_correction=False, model=None,
     debug=False, expected_schema=None
 ):
+    args_dict = json.loads(args_json) if args_json else {}
     output = None
     retry_count = 0
     while retry_count < max_retries:
@@ -1629,7 +1631,7 @@ def generate_simple_music_prompts(
     
         output_essence = run_chain_with_retries(
             chain,
-            args_dict={"input": input_text},
+            args_json=json.dumps({"input": input_text}, sort_keys=True),
             max_retries=max_retries,
             model=model,
             debug=debug,
@@ -1654,11 +1656,12 @@ def generate_simple_music_prompts(
         # Run the chain with retries
         parsed_output = run_chain_with_retries(
             gen_chain,
-            args_dict={
+            args_json=json.dumps({
                 "input": input_text,
                 "essence":output_essence["essence_and_facets"]["essence"],
                 "facets":output_essence["essence_and_facets"]["facets"],
-                "style_axes":output_essence["essence_and_facets"]["style_axes"]},
+                "style_axes":output_essence["essence_and_facets"]["style_axes"]
+            }, sort_keys=True),
             max_retries=max_retries,
             model=model,
             debug=debug,


### PR DESCRIPTION
## Summary
- Refactor `run_llm_chain` and `run_chain_with_retries` to serialize LLM arguments to JSON for caching
- Update music and image generation helpers to pass JSON-encoded args
- Import `json` where needed

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e7189b9988329a0793e71b16b76e1