### PR TITLE
Handle creativity spectrum in facets processing

### DIFF
--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -1421,6 +1421,7 @@ def process_facets(
     max_retries,
     debug=False,
     style_axes=None,
+    creativity_spectrum=None,
     model=None,
     image_context=None
 ):
@@ -1431,6 +1432,12 @@ def process_facets(
         "medium": medium,
         "style_axes": style_axes
     }
+    if creativity_spectrum is not None:
+        args.update({
+            "creativity_spectrum_transformative": creativity_spectrum['transformative'],
+            "creativity_spectrum_inventive": creativity_spectrum['inventive'],
+            "creativity_spectrum_literal": creativity_spectrum['literal'],
+        })
     if image_context is not None:
         args["image_context"] = str(image_context)
     parsed_output = run_llm_chain(

--- a/tests/test_process_facets.py
+++ b/tests/test_process_facets.py
@@ -1,0 +1,31 @@
+import os
+import sys
+from pathlib import Path
+
+# Ensure project root is on the Python path for direct test execution
+project_root = Path(__file__).resolve().parent.parent
+sys.path.append(str(project_root))
+
+# Create a temporary symlink so llm_integration can load prompt files
+symlink_path = Path('/lofn')
+if not symlink_path.exists():
+    symlink_path.symlink_to(project_root / 'lofn', target_is_directory=True)
+
+import lofn.llm_integration as li
+
+
+def test_process_facets_creativity_spectrum(monkeypatch):
+    captured = {}
+
+    def fake_run_llm_chain(chains, name, args, max_retries, model, debug, expected_schema=None):
+        captured['args'] = args
+        return {'facets': []}
+
+    monkeypatch.setattr(li, 'run_llm_chain', fake_run_llm_chain)
+
+    cs = {'transformative': 10, 'inventive': 20, 'literal': 70}
+    li.process_facets({}, 'text', 'concept', 'medium', 1, creativity_spectrum=cs)
+
+    assert captured['args']['creativity_spectrum_transformative'] == 10
+    assert captured['args']['creativity_spectrum_inventive'] == 20
+    assert captured['args']['creativity_spectrum_literal'] == 70


### PR DESCRIPTION
## Summary
- Allow `process_facets` to accept a creativity spectrum and forward its values to the facets LLM chain
- Add unit test covering the new creativity spectrum argument

## Testing
- `pytest tests/test_process_facets.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689fc0f32500832990caf32de3f8b0b3