### PR TITLE
Use OpenAI-compatible image_url type for image chats

### DIFF
--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -403,16 +403,22 @@ def prepare_image_messages(images: List) -> List[HumanMessage]:
                 url = f"data:{mime};base64,{encoded}"
 
             if mime and mime.startswith("image/"):
-                media_type = "input_image"
+                media_type = "image_url"
             elif mime and mime.startswith("video/"):
                 media_type = "input_video"
         except Exception:
             continue
 
-        if media_type == "input_image":
-            messages.append(HumanMessage(content=[{"type": media_type, "image_url": url}]))
+        if media_type == "image_url":
+            messages.append(
+                HumanMessage(
+                    content=[{"type": media_type, "image_url": {"url": url}}]
+                )
+            )
         elif media_type == "input_video":
-            messages.append(HumanMessage(content=[{"type": media_type, "video_url": url}]))
+            messages.append(
+                HumanMessage(content=[{"type": media_type, "video_url": url}])
+            )
 
     return messages
 
@@ -428,8 +434,12 @@ def prepare_image_strings(images: List) -> List[str]:
     urls = []
     for m in prepare_image_messages(images):
         part = m.content[0]
-        if part["type"] == "input_image":
-            urls.append(part.get("image_url", ""))
+        if part["type"] == "image_url":
+            image_data = part.get("image_url", {})
+            if isinstance(image_data, dict):
+                urls.append(image_data.get("url", ""))
+            else:
+                urls.append(image_data)
         elif part["type"] == "input_video":
             urls.append(part.get("video_url", ""))
     return urls

--- a/lofn/ui.py
+++ b/lofn/ui.py
@@ -1587,9 +1587,13 @@ class LofnApp:
                 for media in prepared:
                     part = media.content[0]
                     url = part.get("image_url") or part.get("video_url")
-                    if part["type"] == "input_image":
+                    if part["type"] in ("image_url", "input_image"):
+                        if isinstance(url, dict):
+                            url = url.get("url", "")
                         st.image(base64.b64decode(url.split(",")[1]))
-                    elif part["type"] == "input_video":
+                    elif part["type"] in ("video_url", "input_video"):
+                        if isinstance(url, dict):
+                            url = url.get("url", "")
                         st.video(base64.b64decode(url.split(",")[1]))
             response_stream = stream_personality_chat(
                 personality_text,
@@ -1697,9 +1701,13 @@ class LofnApp:
                 for media in prepared:
                     part = media.content[0]
                     url = part.get("image_url") or part.get("video_url")
-                    if part["type"] == "input_image":
+                    if part["type"] in ("image_url", "input_image"):
+                        if isinstance(url, dict):
+                            url = url.get("url", "")
                         st.image(base64.b64decode(url.split(",")[1]))
-                    elif part["type"] == "input_video":
+                    elif part["type"] in ("video_url", "input_video"):
+                        if isinstance(url, dict):
+                            url = url.get("url", "")
                         st.video(base64.b64decode(url.split(",")[1]))
             response_stream = stream_personality_image2video_chat(
                 personality_text,

--- a/tests/test_image_inputs.py
+++ b/tests/test_image_inputs.py
@@ -30,6 +30,6 @@ def test_prepare_image_messages_limit():
     msgs = prepare_image_messages(images)
     assert len(msgs) == 5
     for m in msgs:
-        assert m.content[0]["type"] == "input_image"
-        assert m.content[0]["image_url"].startswith("data:image/")
+        assert m.content[0]["type"] == "image_url"
+        assert m.content[0]["image_url"]["url"].startswith("data:image/")
         assert m.additional_kwargs == {}

--- a/tests/test_prepare_image_messages.py
+++ b/tests/test_prepare_image_messages.py
@@ -51,8 +51,8 @@ def test_prepare_image_messages_inlines_jpeg():
     assert len(msgs) == 1
     msg = msgs[0]
     assert isinstance(msg.content, list)
-    assert msg.content[0]["type"] == "input_image"
-    url = msg.content[0]["image_url"]
+    assert msg.content[0]["type"] == "image_url"
+    url = msg.content[0]["image_url"]["url"]
     assert url.startswith("data:image/jpeg;base64")
     assert msg.additional_kwargs == {}
 


### PR DESCRIPTION
## Summary
- switch chat image media type from `input_image` to `image_url` for OpenAI compatibility
- update UI chat rendering to handle new image/video message parts
- adjust tests for new image_url structure

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689fc1ac633c8329bd0cb7da95669682