### PR TITLE
Sanitize music metadata filenames and prevent widget ID collisions

### DIFF
--- a/lofn/image_generation.py
+++ b/lofn/image_generation.py
@@ -985,7 +985,8 @@ def save_metadata(metadata):
 
 def save_music_metadata(metadata):
     os.makedirs('/music', exist_ok=True)
-    metadata_filename = f"/music/{metadata['timestamp']}_{metadata['title'][0:10]}.json"
+    safe_title = metadata['title'][0:10].replace('/', '_')
+    metadata_filename = f"/music/{metadata['timestamp']}_{safe_title}.json"
 
     def json_serializable(obj):
         if isinstance(obj, datetime):

--- a/lofn/ui.py
+++ b/lofn/ui.py
@@ -934,8 +934,6 @@ class LofnApp:
                 self.generate_music_prompts_for_pair(pair)
 
             st.success("Music prompts generated successfully!")
-            if st.session_state.get('music_concept_mediums'):
-                self.display_music_concepts()
         except Exception as e:
             st.error("An error occurred during music competition mode.")
             logger.exception("Error in music competition: %s", e)


### PR DESCRIPTION
## Summary
- Sanitize music prompt titles when creating music metadata filenames to avoid `FileNotFoundError` if a title contains slashes
- Remove extra call to `display_music_concepts` in music competition flow to prevent Streamlit duplicate widget keys

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml', 'PIL', 'openai')*


------
https://chatgpt.com/codex/tasks/task_e_68a7a742e6408329b3ef42c36a4a7925