### PR TITLE
Fix TikTok mode session state conflict

### DIFF
--- a/lofn/image_generation.py
+++ b/lofn/image_generation.py
@@ -909,7 +909,10 @@ def render_image_controls(model: str):
     else:
         st.selectbox("Image Size", ["1024x1024", "512x512", "768x768", "512x768", "768x512"], key=f"{model}_image_size")
     
-    st.number_input("Number of Images", min_value=1, max_value=10, value=1, key=f"{model}_num_images")
+    num_images_key = f"{model}_num_images"
+    if num_images_key not in st.session_state:
+        st.session_state[num_images_key] = 1
+    st.number_input("Number of Images", min_value=1, max_value=10, key=num_images_key)
 
 def update_image_controls():
     # Clear previous image controls

--- a/lofn/ui.py
+++ b/lofn/ui.py
@@ -455,8 +455,8 @@ class LofnApp:
             st.session_state['tiktok_mode'] = tiktok_mode
             if tiktok_mode:
                 self.image_model = 'fal-ai/flux-pro/v1.1-ultra'
-                st.session_state.setdefault('fal-ai/flux-pro/v1.1-ultra_image_size', '9:16')
-                st.session_state.setdefault('fal-ai/flux-pro/v1.1-ultra_num_images', 1)
+                st.session_state['fal-ai/flux-pro/v1.1-ultra_image_size'] = '9:16'
+                st.session_state['fal-ai/flux-pro/v1.1-ultra_num_images'] = 1
             render_image_controls(self.image_model)
 
         with st.sidebar.expander("Style Personalization", expanded=False):


### PR DESCRIPTION
## Summary
- avoid Streamlit widget conflict by storing TikTok mode defaults directly in session state
- read image count from session state without specifying conflicting default value

## Testing
- `python -m pytest tests/test_image_compression.py::test_resize_image_to_data_url_limits_size_and_format -q`
- `python -m pytest tests/test_json_parsing.py -q`
- `python -m pytest -q` *(fails: ImportError: cannot import name 'HTTPError')*


------
https://chatgpt.com/codex/tasks/task_e_68b06b23d5608329a67970a7fd56590a