### PR TITLE
Enable search for supported models

### DIFF
--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -184,6 +184,17 @@ VISION_MODELS = {
     "poe": {"*"},
 }
 
+# Models that can leverage web search. The list is kept as prefixes so that
+# variants like ``-mini`` or ``-nano`` are automatically included.
+SEARCH_PREFIXES = ("gpt-5", "gpt-4.1", "o3", "o4")
+
+
+def _supports_search(model_name: str) -> bool:
+    """Return True if ``model_name`` should have web search enabled."""
+
+    base = model_name.split("/")[-1]  # Strip provider prefix from OR models
+    return any(base.startswith(pref) for pref in SEARCH_PREFIXES)
+
 
 def _supports_vision(model_name: str) -> bool:
     for models in VISION_MODELS.values():
@@ -260,10 +271,15 @@ def call_openai_with_images(user_text: str, images: List[ImageAsset], model: str
     for img in images:
         parts.append({"type": "image_url", "image_url": {"url": img.data_url}, "detail": "low"})
 
+    kwargs = {}
+    if _supports_search(model):
+        kwargs["tools"] = [{"type": "web_search"}]
+
     resp = client.chat.completions.create(
         model=model,
         messages=[{"role": "user", "content": parts}],
         temperature=0.2,
+        **kwargs,
     )
     text = resp.choices[0].message.content or ""
     usage = getattr(resp, "usage", None)
@@ -341,6 +357,8 @@ def call_openrouter_with_images(user_text: str, images: List[ImageAsset], model:
         "messages": [{"role": "user", "content": parts}],
         "temperature": 0.2,
     }
+    if _supports_search(model):
+        payload["tools"] = [{"type": "web_search"}]
     r = requests.post("https://openrouter.ai/api/v1/chat/completions", headers=headers, data=json.dumps(payload))
     r.raise_for_status()
     data = r.json()
@@ -818,6 +836,9 @@ class OpenRouterLLM(LLM):
             "max_tokens": self.max_tokens,
         }
 
+        if _supports_search(self.model_name):
+            data["tools"] = [{"type": "web_search"}]
+
         if stop is not None:
             data["stop"] = stop
 
@@ -1115,20 +1136,16 @@ def get_llm(model, temperature, OPENAI_API=None, ANTHROPIC_API=None, debug=False
                 openai_api_key=Config.LOCAL_LLM_API_KEY,
                 openai_api_base=Config.LOCAL_LLM_API_BASE,
             )
-        elif model.startswith("gpt-5"):
-            return ChatOpenAI(
-                model=model,
-                temperature=1,
-                max_completion_tokens=max_tokens,
-                openai_api_key=Config.OPENAI_API,
-            )
-        elif model.startswith("gpt-4.1"):
-            return ChatOpenAI(
-                model=model,
-                temperature=1,
-                max_completion_tokens=max_tokens,
-                openai_api_key=Config.OPENAI_API,
-            )
+        elif model.startswith("gpt-5") or model.startswith("gpt-4.1"):
+            kwargs = {
+                "model": model,
+                "temperature": 1,
+                "max_completion_tokens": max_tokens,
+                "openai_api_key": Config.OPENAI_API,
+            }
+            if _supports_search(model):
+                kwargs["model_kwargs"] = {"tools": [{"type": "web_search"}]}
+            return ChatOpenAI(**kwargs)
         elif model.startswith("gpt"):
             return ChatOpenAI(
                 model=model,

--- a/lofn/o1_integration.py
+++ b/lofn/o1_integration.py
@@ -13,6 +13,16 @@ from langchain_core.callbacks.manager import CallbackManagerForLLMRun
 from langchain_core.pydantic_v1 import Field, PrivateAttr, root_validator
 from openai import OpenAI  # openai>=1.0.0 style usage
 
+SEARCH_PREFIXES = ("gpt-5", "gpt-4.1", "o3", "o4")
+
+
+def _supports_search(model_name: str) -> bool:
+    """Return True if ``model_name`` should have web search enabled."""
+
+    base = model_name.split("/")[-1]
+    return any(base.startswith(pref) for pref in SEARCH_PREFIXES)
+
+
 def _decide_max_completion_tokens(level: str) -> int:
     """
     Convert 'low'/'medium'/'high' to total tokens for the o1 or o1-mini models.
@@ -93,6 +103,9 @@ class O1ChatOpenAI(BaseChatModel):
         # We'll pass max_completion_tokens plus any user overrides
         final_kwargs = {"max_completion_tokens": self.max_completion_tokens, "reasoning_effort": self.reasoning_level}
         final_kwargs.update(kwargs)
+
+        if _supports_search(self.model_name):
+            final_kwargs.setdefault("tools", [{"type": "web_search"}])
 
         openai_messages = self._convert_langchain_messages(messages)
 


### PR DESCRIPTION
## Summary
- detect search-capable model prefixes (gpt-5, gpt-4.1, o3, o4)
- request web search tool for OpenAI and OpenRouter models using these prefixes
- add search support to O1ChatOpenAI and OpenRouterLLM

## Testing
- `pytest` *(fails: ImportError: cannot import name 'HTTPError')*


------
https://chatgpt.com/codex/tasks/task_e_68b215e1a2d4832986d6b725985d0add