### PR TITLE
Fix chat image message handling

### DIFF
--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -480,16 +480,16 @@ def prepare_image_messages(images: List) -> List[HumanMessage]:
                 url = f"data:{mime};base64,{encoded}"
 
             if mime and mime.startswith("image/"):
-                media_type = "image_url"
+                media_type = "input_image"
             elif mime and mime.startswith("video/"):
                 media_type = "input_video"
         except Exception:
             continue
 
-        if media_type == "image_url":
+        if media_type == "input_image":
             messages.append(
                 HumanMessage(
-                    content=[{"type": media_type, "image_url": {"url": url}}]
+                    content=[{"type": media_type, "image_url": url}]
                 )
             )
         elif media_type == "input_video":
@@ -511,7 +511,7 @@ def prepare_image_strings(images: List) -> List[str]:
     urls = []
     for m in prepare_image_messages(images):
         part = m.content[0]
-        if part["type"] == "image_url":
+        if part["type"] in ("image_url", "input_image"):
             image_data = part.get("image_url", {})
             if isinstance(image_data, dict):
                 urls.append(image_data.get("url", ""))

--- a/tests/test_image_inputs.py
+++ b/tests/test_image_inputs.py
@@ -30,6 +30,6 @@ def test_prepare_image_messages_limit():
     msgs = prepare_image_messages(images)
     assert len(msgs) == 5
     for m in msgs:
-        assert m.content[0]["type"] == "image_url"
-        assert m.content[0]["image_url"]["url"].startswith("data:image/")
+        assert m.content[0]["type"] == "input_image"
+        assert m.content[0]["image_url"].startswith("data:image/")
         assert m.additional_kwargs == {}

--- a/tests/test_prepare_image_messages.py
+++ b/tests/test_prepare_image_messages.py
@@ -51,8 +51,8 @@ def test_prepare_image_messages_inlines_jpeg():
     assert len(msgs) == 1
     msg = msgs[0]
     assert isinstance(msg.content, list)
-    assert msg.content[0]["type"] == "image_url"
-    url = msg.content[0]["image_url"]["url"]
+    assert msg.content[0]["type"] == "input_image"
+    url = msg.content[0]["image_url"]
     assert url.startswith("data:image/jpeg;base64")
     assert msg.additional_kwargs == {}
 


### PR DESCRIPTION
## Summary
- ensure `prepare_image_messages` emits `input_image` messages with direct data URLs
- allow `prepare_image_strings` to read `input_image` format
- update image-related tests for new schema

## Testing
- `PYTHONPATH=. pytest tests/test_image_inputs.py tests/test_prepare_image_messages.py -q`
- `PYTHONPATH=. pytest -q` *(fails: ImportError: cannot import name 'HTTPError')*


------
https://chatgpt.com/codex/tasks/task_e_68b516437a108329ac6353f4355b4f23