### PR TITLE
Handle OpenAI image/video message format

### DIFF
--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -236,7 +236,7 @@ def call_openai_gpt5_multimodal(
             img_bytes, mime = normalize_image_bytes(blob)
             data_url = to_data_url(img_bytes, mime)
             user_content.append(
-                {"type": "input_image", "image_url": data_url, "detail": "high"}
+                {"type": "input_image", "image_url": {"url": data_url}, "detail": "high"}
             )
 
     user_content.append({"type": "input_text", "text": user_text})
@@ -489,12 +489,14 @@ def prepare_image_messages(images: List) -> List[HumanMessage]:
         if media_type == "input_image":
             messages.append(
                 HumanMessage(
-                    content=[{"type": media_type, "image_url": url}]
+                    content=[{"type": media_type, "image_url": {"url": url}}]
                 )
             )
         elif media_type == "input_video":
             messages.append(
-                HumanMessage(content=[{"type": media_type, "video_url": url}])
+                HumanMessage(
+                    content=[{"type": media_type, "video_url": {"url": url}}]
+                )
             )
 
     return messages
@@ -514,11 +516,15 @@ def prepare_image_strings(images: List) -> List[str]:
         if part["type"] in ("image_url", "input_image"):
             image_data = part.get("image_url", {})
             if isinstance(image_data, dict):
-                urls.append(image_data.get("url", ""))
+                urls.append(image_data.get("url") or image_data.get("file_id", ""))
             else:
                 urls.append(image_data)
         elif part["type"] == "input_video":
-            urls.append(part.get("video_url", ""))
+            video_data = part.get("video_url", {})
+            if isinstance(video_data, dict):
+                urls.append(video_data.get("url") or video_data.get("file_id", ""))
+            else:
+                urls.append(video_data)
     return urls
 
 # Load prompts

--- a/tests/test_image_inputs.py
+++ b/tests/test_image_inputs.py
@@ -31,5 +31,5 @@ def test_prepare_image_messages_limit():
     assert len(msgs) == 5
     for m in msgs:
         assert m.content[0]["type"] == "input_image"
-        assert m.content[0]["image_url"].startswith("data:image/")
+        assert m.content[0]["image_url"]["url"].startswith("data:image/")
         assert m.additional_kwargs == {}

--- a/tests/test_prepare_image_messages.py
+++ b/tests/test_prepare_image_messages.py
@@ -52,7 +52,7 @@ def test_prepare_image_messages_inlines_jpeg():
     msg = msgs[0]
     assert isinstance(msg.content, list)
     assert msg.content[0]["type"] == "input_image"
-    url = msg.content[0]["image_url"]
+    url = msg.content[0]["image_url"]["url"]
     assert url.startswith("data:image/jpeg;base64")
     assert msg.additional_kwargs == {}
 
@@ -65,4 +65,4 @@ def test_prepare_image_messages_handles_video():
     assert len(msgs) == 1
     part = msgs[0].content[0]
     assert part["type"] == "input_video"
-    assert part["video_url"].startswith("data:video/mp4;base64")
+    assert part["video_url"]["url"].startswith("data:video/mp4;base64")


### PR DESCRIPTION
## Summary
- Wrap uploaded image and video data in `image_url`/`video_url` objects to match OpenAI Responses API schema
- Update helpers and OpenAI call to use new format for multimodal requests
- Adjust tests for updated message structure

## Testing
- `PYTHONPATH=$PWD pytest tests/test_prepare_image_messages.py tests/test_image_inputs.py tests/test_image_flow.py -q` *(fails: No module named 'langchain_anthropic')*


------
https://chatgpt.com/codex/tasks/task_e_68b519526a988329baec3e23a3bc164b