### PR TITLE
Fix OpenAI image upload handling

### DIFF
--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -27,8 +27,8 @@ from langchain_core.language_models.llms import LLM
 from typing import Any, Dict, List, Optional, Tuple
 from dataclasses import dataclass
 import imghdr
-from config import Config
-from helpers import (
+from .config import Config
+from .helpers import (
         read_prompt,
         send_to_discord,
         parse_output,
@@ -51,16 +51,16 @@ import base64
 import mimetypes
 from PIL import Image
 import io
-from helpers import (
+from .helpers import (
         display_temporary_results,
         display_temporary_results_no_expander
 )
 from langchain_core.callbacks.manager import CallbackManagerForLLMRun
 import openai  # For the advanced "o1" usage if needed
 from openai import OpenAI
-from o1_integration import *  # noqa: F401,F403
+from .o1_integration import *  # noqa: F401,F403
 from pathlib import Path
-from utils.image_io import normalize_image_bytes, to_data_url
+from .utils.image_io import normalize_image_bytes, to_data_url
 
 class LofnError(Exception):
     """Custom exception class for Lofn-specific errors."""
@@ -233,10 +233,16 @@ def call_openai_gpt5_multimodal(
 
     if image_blobs:
         for blob in image_blobs:
-            img_bytes, mime = normalize_image_bytes(blob)
-            data_url = to_data_url(img_bytes, mime)
+            img_bytes, _ = normalize_image_bytes(blob)
+            uploaded = client.files.create(
+                file=io.BytesIO(img_bytes), purpose="vision"
+            )
             user_content.append(
-                {"type": "input_image", "image_url": data_url, "detail": "high"}
+                {
+                    "type": "input_image",
+                    "image_url": {"file_id": uploaded.id},
+                    "detail": "high",
+                }
             )
 
     user_content.append({"type": "input_text", "text": user_text})

--- a/tests/test_image_flow.py
+++ b/tests/test_image_flow.py
@@ -15,10 +15,19 @@ def test_openai_accepts_image(monkeypatch):
         def create(**kwargs):
             assert kwargs["model"].startswith("gpt-5")
             inp = kwargs["input"][-1]["content"]
-            assert any(x.get("type") == "input_image" for x in inp)
+            assert any(
+                x.get("type") == "input_image" and "file_id" in x.get("image_url", {})
+                for x in inp
+            )
             return type("R", (), {"output_text": "ok"})
 
+    class FakeFiles:
+        @staticmethod
+        def create(**kwargs):
+            return type("F", (), {"id": "file-123"})
+
     class FakeClient:
+        files = FakeFiles()
         responses = FakeResponses()
 
     monkeypatch.setattr(li, "OpenAI", lambda: FakeClient())


### PR DESCRIPTION
## Summary
- Upload chat images to OpenAI with `purpose="vision"` and reference them via `image_url.file_id`
- Convert imports in `llm_integration` to package-relative modules
- Update image flow test to expect file-based image URLs

## Testing
- `PYTHONPATH=. pytest tests/test_image_flow.py::test_openai_accepts_image -q`
- `PYTHONPATH=. pytest -q` *(fails: ImportError: cannot import name 'HTTPError' from '<unknown module name>')*

------
https://chatgpt.com/codex/tasks/task_e_68b519526a988329baec3e23a3bc164b