### PR TITLE
Add debug logging and unify chat interface

### DIFF
--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -2369,7 +2369,19 @@ def run_personality_chat(
         MessagesPlaceholder("chat_history"),
     ])
     chain = prompt | llm
+    if debug:
+        logger.debug(
+            "Personality chat request",
+            extra={
+                "personality_prompt": personality_prompt,
+                "chat_history": chat_history,
+                "user_input": user_input,
+                "input_media": input_media,
+            },
+        )
     response = chain.invoke({"chat_history": chat_history + [user_message]})
+    if debug:
+        logger.debug("Personality chat response: %s", response)
     if isinstance(response, dict):
         return response.get("text", str(response))
     if hasattr(response, "content"):
@@ -2454,6 +2466,16 @@ def run_personality_image2video_chat(
     input_media: Optional[List[Dict[str, str]]] = None,
 ):
     """Run a chat using the image-to-video personality template."""
+    if debug:
+        logger.debug(
+            "Image-to-video chat request",
+            extra={
+                "personality_prompt": personality_prompt,
+                "chat_history": chat_history,
+                "user_input": user_input,
+                "input_media": input_media,
+            },
+        )
     return run_personality_chat(
         personality_prompt,
         chat_history,

--- a/lofn/ui.py
+++ b/lofn/ui.py
@@ -315,8 +315,7 @@ class LofnApp:
             "Image Generation",
             "Video Generation",
             "Music Generation",
-            "Personality Chat",
-            "Image to Video Chat",
+            "Chat",
             "Prompt Explorer",
         ]
         current_tab = st.session_state.get('selected_tab', tabs[0])
@@ -336,12 +335,10 @@ class LofnApp:
             self.render_video_generation()
         elif selected_tab == "Music Generation":
             self.render_music_generation()
-        elif selected_tab == "Image to Video Chat":
-            self.render_image_to_video_chat()
+        elif selected_tab == "Chat":
+            self.render_chat()
         elif selected_tab == "Prompt Explorer":
             self.render_prompt_explorer()
-        elif selected_tab == "Personality Chat":
-            self.render_personality_chat()
 
     def render_sidebar(self):
         st.sidebar.header('Settings')
@@ -1507,8 +1504,15 @@ class LofnApp:
             with st.expander("Input Settings"):
                 st.json(data.get("input_settings"))
 
-    def render_personality_chat(self):
-        st.header("Personality Chat")
+    def render_chat(self):
+        col1, col2 = st.columns(2)
+        with col1:
+            self.render_personality_chat_section()
+        with col2:
+            self.render_image_to_video_chat_section()
+
+    def render_personality_chat_section(self):
+        st.subheader("Personality Chat")
         personality_names = [p['name'] for p in PERSONALITY_OPTIONS] + ['Custom']
         st.session_state['selected_personality'] = st.selectbox(
             'Personality',
@@ -1604,7 +1608,8 @@ class LofnApp:
                         if isinstance(url, dict):
                             url = url.get("url", "")
                         st.video(base64.b64decode(url.split(",")[1]))
-            response_stream = stream_personality_chat(
+            logger.debug("Personality chat user input: %s", user_input)
+            response_text = run_personality_chat(
                 personality_text,
                 history,
                 user_input,
@@ -1614,16 +1619,15 @@ class LofnApp:
                 debug=self.debug,
                 input_media=[m.content[0] for m in prepared],
             )
+            logger.debug("Personality chat response: %s", response_text)
             with st.chat_message("assistant"):
-                response_text = st.write_stream(
-                    async_to_sync_generator(response_stream)
-                )
+                st.markdown(response_text)
             st.session_state['chat_history'].append(AIMessage(content=response_text))
         st.session_state['chat_input_images'] = []
         st.session_state['clear_personality_chat_images'] = True
 
-    def render_image_to_video_chat(self):
-        st.header("Image to Video Chat")
+    def render_image_to_video_chat_section(self):
+        st.subheader("Image to Video Chat")
         personality_names = [p['name'] for p in PERSONALITY_OPTIONS] + ['Custom']
         st.session_state['image2video_selected_personality'] = st.selectbox(
             'Personality',
@@ -1718,7 +1722,8 @@ class LofnApp:
                         if isinstance(url, dict):
                             url = url.get("url", "")
                         st.video(base64.b64decode(url.split(",")[1]))
-            response_stream = stream_personality_image2video_chat(
+            logger.debug("Image-to-video chat user input: %s", user_input)
+            response_text = run_personality_image2video_chat(
                 personality_text,
                 history,
                 user_input,
@@ -1728,10 +1733,9 @@ class LofnApp:
                 debug=self.debug,
                 input_media=[m.content[0] for m in prepared],
             )
+            logger.debug("Image-to-video chat response: %s", response_text)
             with st.chat_message("assistant"):
-                response_text = st.write_stream(
-                    async_to_sync_generator(response_stream)
-                )
+                st.markdown(response_text)
             st.session_state['image2video_chat_history'].append(AIMessage(content=response_text))
             st.session_state['image2video_chat_input_images'] = []
             st.session_state['clear_image2video_chat_images'] = True

--- a/tests/test_art_styles.py
+++ b/tests/test_art_styles.py
@@ -3,9 +3,19 @@ import os
 import types
 
 # Stub dependencies
-streamlit_stub = types.SimpleNamespace(session_state={})
+streamlit_stub = types.SimpleNamespace(
+    write=lambda *a, **k: None,
+    code=lambda *a, **k: None,
+    warning=lambda *a, **k: None,
+    session_state={},
+    cache_data=lambda *a, **k: (lambda f: f),
+)
 sys.modules['streamlit'] = streamlit_stub
-sys.modules['requests'] = types.SimpleNamespace(post=lambda *a, **k: None)
+sys.modules['requests'] = types.SimpleNamespace(
+    post=lambda *a, **k: None,
+    HTTPError=Exception,
+    Response=object,
+)
 sys.modules['json_repair'] = types.SimpleNamespace(repair_json=lambda s: s)
 
 plotly_module = types.ModuleType("plotly")

--- a/tests/test_async_stream.py
+++ b/tests/test_async_stream.py
@@ -3,8 +3,18 @@ import os
 import types
 
 # Stub dependencies not available in the test environment
-sys.modules['streamlit'] = types.SimpleNamespace(write=lambda *a, **k: None, code=lambda *a, **k: None)
-sys.modules['requests'] = types.SimpleNamespace(post=lambda *a, **k: None)
+sys.modules['streamlit'] = types.SimpleNamespace(
+    write=lambda *a, **k: None,
+    code=lambda *a, **k: None,
+    warning=lambda *a, **k: None,
+    session_state={},
+    cache_data=lambda *a, **k: (lambda f: f),
+)
+sys.modules['requests'] = types.SimpleNamespace(
+    post=lambda *a, **k: None,
+    HTTPError=Exception,
+    Response=object,
+)
 sys.modules['json_repair'] = types.SimpleNamespace(repair_json=lambda s: s)
 
 plotly_module = types.ModuleType("plotly")

--- a/tests/test_film_styles.py
+++ b/tests/test_film_styles.py
@@ -3,9 +3,19 @@ import os
 import types
 
 # Stub dependencies
-streamlit_stub = types.SimpleNamespace(session_state={})
+streamlit_stub = types.SimpleNamespace(
+    write=lambda *a, **k: None,
+    code=lambda *a, **k: None,
+    warning=lambda *a, **k: None,
+    session_state={},
+    cache_data=lambda *a, **k: (lambda f: f),
+)
 sys.modules['streamlit'] = streamlit_stub
-sys.modules['requests'] = types.SimpleNamespace(post=lambda *a, **k: None)
+sys.modules['requests'] = types.SimpleNamespace(
+    post=lambda *a, **k: None,
+    HTTPError=Exception,
+    Response=object,
+)
 sys.modules['json_repair'] = types.SimpleNamespace(repair_json=lambda s: s)
 
 plotly_module = types.ModuleType("plotly")

--- a/tests/test_json_parsing.py
+++ b/tests/test_json_parsing.py
@@ -3,8 +3,18 @@ import os
 import types
 
 # Stub dependencies not available in the test environment
-sys.modules['streamlit'] = types.SimpleNamespace(write=lambda *a, **k: None, code=lambda *a, **k: None)
-sys.modules['requests'] = types.SimpleNamespace(post=lambda *a, **k: None)
+sys.modules['streamlit'] = types.SimpleNamespace(
+    write=lambda *a, **k: None,
+    code=lambda *a, **k: None,
+    warning=lambda *a, **k: None,
+    session_state={},
+    cache_data=lambda *a, **k: (lambda f: f),
+)
+sys.modules['requests'] = types.SimpleNamespace(
+    post=lambda *a, **k: None,
+    HTTPError=Exception,
+    Response=object,
+)
 sys.modules['json_repair'] = types.SimpleNamespace(repair_json=lambda s: s)
 
 plotly_module = types.ModuleType("plotly")

--- a/tests/test_music_frames.py
+++ b/tests/test_music_frames.py
@@ -3,9 +3,19 @@ import os
 import types
 
 # Stub dependencies
-streamlit_stub = types.SimpleNamespace(session_state={})
+streamlit_stub = types.SimpleNamespace(
+    write=lambda *a, **k: None,
+    code=lambda *a, **k: None,
+    warning=lambda *a, **k: None,
+    session_state={},
+    cache_data=lambda *a, **k: (lambda f: f),
+)
 sys.modules['streamlit'] = streamlit_stub
-sys.modules['requests'] = types.SimpleNamespace(post=lambda *a, **k: None)
+sys.modules['requests'] = types.SimpleNamespace(
+    post=lambda *a, **k: None,
+    HTTPError=Exception,
+    Response=object,
+)
 sys.modules['json_repair'] = types.SimpleNamespace(repair_json=lambda s: s)
 
 plotly_module = types.ModuleType("plotly")

--- a/tests/test_music_genres.py
+++ b/tests/test_music_genres.py
@@ -3,9 +3,19 @@ import os
 import types
 
 # Stub dependencies
-streamlit_stub = types.SimpleNamespace(session_state={})
+streamlit_stub = types.SimpleNamespace(
+    write=lambda *a, **k: None,
+    code=lambda *a, **k: None,
+    warning=lambda *a, **k: None,
+    session_state={},
+    cache_data=lambda *a, **k: (lambda f: f),
+)
 sys.modules['streamlit'] = streamlit_stub
-sys.modules['requests'] = types.SimpleNamespace(post=lambda *a, **k: None)
+sys.modules['requests'] = types.SimpleNamespace(
+    post=lambda *a, **k: None,
+    HTTPError=Exception,
+    Response=object,
+)
 sys.modules['json_repair'] = types.SimpleNamespace(repair_json=lambda s: s)
 
 plotly_module = types.ModuleType("plotly")

--- a/tests/test_style_axes.py
+++ b/tests/test_style_axes.py
@@ -3,9 +3,19 @@ import os
 import types
 
 # Stub dependencies
-streamlit_stub = types.SimpleNamespace(session_state={})
+streamlit_stub = types.SimpleNamespace(
+    write=lambda *a, **k: None,
+    code=lambda *a, **k: None,
+    warning=lambda *a, **k: None,
+    session_state={},
+    cache_data=lambda *a, **k: (lambda f: f),
+)
 sys.modules['streamlit'] = streamlit_stub
-sys.modules['requests'] = types.SimpleNamespace(post=lambda *a, **k: None)
+sys.modules['requests'] = types.SimpleNamespace(
+    post=lambda *a, **k: None,
+    HTTPError=Exception,
+    Response=object,
+)
 sys.modules['json_repair'] = types.SimpleNamespace(repair_json=lambda s: s)
 
 plotly_module = types.ModuleType("plotly")


### PR DESCRIPTION
## Summary
- log personality chat requests and responses for easier debugging
- merge chat modes into one tab with side-by-side text and image prompts
- extend test stubs for requests/streamlit to satisfy LangChain imports

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b51f14b0148329b99422e5c4525210