### PR TITLE
Assign unique keys to chat input widgets

### DIFF
--- a/lofn/ui.py
+++ b/lofn/ui.py
@@ -1586,7 +1586,7 @@ class LofnApp:
                 else:
                     st.markdown(msg.content)
 
-        user_input = st.chat_input("Send a message")
+        user_input = st.chat_input("Send a message", key="personality_chat_input")
         if user_input:
             history = st.session_state['chat_history'][:]
             images = st.session_state.get('chat_input_images', [])
@@ -1700,7 +1700,7 @@ class LofnApp:
                 else:
                     st.markdown(msg.content)
 
-        user_input = st.chat_input("Send a message")
+        user_input = st.chat_input("Send a message", key="image2video_chat_input")
         if user_input:
             history = st.session_state['image2video_chat_history'][:]
             images = st.session_state.get('image2video_chat_input_images', [])


### PR DESCRIPTION
## Summary
- add distinct Streamlit `chat_input` keys for personality and image-to-video chats to prevent DuplicateWidgetID errors when both chats are rendered together

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5d8fe0c748329ba1fef1fbd9eefe4