### PR TITLE
Refactor chat UI and update image handling

### DIFF
--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -167,7 +167,7 @@ def _has_image_parts(msgs: List[HumanMessage]) -> bool:
         content = getattr(m, "content", [])
         if isinstance(content, list):
             for part in content:
-                if isinstance(part, dict) and part.get("type") in ("image_url", "input_image", "input_video"):
+                if isinstance(part, dict) and part.get("type") in ("image_url", "file"):
                     return True
     return False
 
@@ -239,18 +239,18 @@ def call_openai_gpt5_multimodal(
             )
             user_content.append(
                 {
-                    "type": "input_image",
+                    "type": "image_url",
                     "image_url": {"file_id": uploaded.id},
                     "detail": "high",
                 }
             )
 
-    user_content.append({"type": "input_text", "text": user_text})
+    user_content.append({"type": "text", "text": user_text})
 
     messages = []
     if system_text:
         messages.append(
-            {"role": "system", "content": [{"type": "input_text", "text": system_text}]}
+            {"role": "system", "content": [{"type": "text", "text": system_text}]}
         )
     messages.append({"role": "user", "content": user_content})
 
@@ -442,7 +442,7 @@ def prepare_image_messages(images: List) -> List[HumanMessage]:
 
     for img in images:
         url = None
-        media_type = None
+        mime = None
 
         try:
             if isinstance(img, str):
@@ -485,22 +485,25 @@ def prepare_image_messages(images: List) -> List[HumanMessage]:
                 encoded = base64.b64encode(data).decode()
                 url = f"data:{mime};base64,{encoded}"
 
-            if mime and mime.startswith("image/"):
-                media_type = "input_image"
-            elif mime and mime.startswith("video/"):
-                media_type = "input_video"
         except Exception:
             continue
 
-        if media_type == "input_image":
+        if mime and mime.startswith("image/"):
             messages.append(
                 HumanMessage(
-                    content=[{"type": media_type, "image_url": url}]
+                    content=[{"type": "image_url", "image_url": {"url": url}}]
                 )
             )
-        elif media_type == "input_video":
+        elif mime and mime.startswith("video/"):
             messages.append(
-                HumanMessage(content=[{"type": media_type, "video_url": url}])
+                HumanMessage(
+                    content=[
+                        {
+                            "type": "file",
+                            "file": {"mime_type": mime, "b64_json": encoded},
+                        }
+                    ]
+                )
             )
 
     return messages
@@ -517,14 +520,18 @@ def prepare_image_strings(images: List) -> List[str]:
     urls = []
     for m in prepare_image_messages(images):
         part = m.content[0]
-        if part["type"] in ("image_url", "input_image"):
+        if part["type"] == "image_url":
             image_data = part.get("image_url", {})
             if isinstance(image_data, dict):
                 urls.append(image_data.get("url", ""))
             else:
                 urls.append(image_data)
-        elif part["type"] == "input_video":
-            urls.append(part.get("video_url", ""))
+        elif part["type"] == "file":
+            file_data = part.get("file", {})
+            mime = file_data.get("mime_type", "")
+            b64 = file_data.get("b64_json", "")
+            if mime and b64:
+                urls.append(f"data:{mime};base64,{b64}")
     return urls
 
 # Load prompts

--- a/lofn/ui.py
+++ b/lofn/ui.py
@@ -1505,49 +1505,55 @@ class LofnApp:
                 st.json(data.get("input_settings"))
 
     def render_chat(self):
-        col1, col2 = st.columns(2)
-        with col1:
-            self.render_personality_chat_section()
-        with col2:
-            self.render_image_to_video_chat_section()
+        mode = st.selectbox(
+            "Chat Mode", ["Personality Chat", "Image to Video Chat"], key="chat_mode"
+        )
+        self.render_chat_section(mode)
 
-    def render_personality_chat_section(self):
-        st.subheader("Personality Chat")
+    def render_chat_section(self, mode):
+        image_mode = mode == "Image to Video Chat"
+        key_prefix = "image2video_" if image_mode else ""
+        st.subheader(mode)
+
         personality_names = [p['name'] for p in PERSONALITY_OPTIONS] + ['Custom']
-        st.session_state['selected_personality'] = st.selectbox(
+        select_key = f"{key_prefix}selected_personality" if key_prefix else "selected_personality"
+        st.session_state[select_key] = st.selectbox(
             'Personality',
             personality_names,
             index=personality_names.index(
-                st.session_state.get('selected_personality', personality_names[0])
+                st.session_state.get(select_key, personality_names[0])
             ),
-            key='chat_personality_select',
+            key=f"{key_prefix}personality_select",
         )
-        if st.session_state['selected_personality'] == 'Custom':
-            st.session_state['custom_personality'] = st.text_area(
+        custom_key = f"{key_prefix}custom_personality" if key_prefix else "custom_personality"
+        if st.session_state[select_key] == 'Custom':
+            st.session_state[custom_key] = st.text_area(
                 'Custom Personality',
-                value=st.session_state.get('custom_personality', ''),
+                value=st.session_state.get(custom_key, ''),
                 height=150,
-                key='chat_custom_personality',
+                key=f"{key_prefix}custom_personality_text",
             )
         else:
-            st.session_state['custom_personality'] = next(
+            st.session_state[custom_key] = next(
                 p['prompt']
                 for p in PERSONALITY_OPTIONS
-                if p['name'] == st.session_state['selected_personality']
+                if p['name'] == st.session_state[select_key]
             )
-        personality_text = st.session_state.get('custom_personality', '')
+        personality_text = st.session_state.get(custom_key, '')
 
-        # Clear uploaded images if a reset was requested before rendering the uploader
-        if st.session_state.get('clear_personality_chat_images'):
-            st.session_state.pop('personality_chat_images', None)
-            st.session_state['clear_personality_chat_images'] = False
+        clear_key = "clear_image2video_chat_images" if image_mode else "clear_personality_chat_images"
+        if st.session_state.get(clear_key):
+            images_key = f"{key_prefix}chat_images" if image_mode else "personality_chat_images"
+            st.session_state.pop(images_key, None)
+            st.session_state[clear_key] = False
 
         st.subheader("Reference Media (Optional)")
+        images_key = f"{key_prefix}chat_images" if image_mode else "personality_chat_images"
         uploaded_files = st.file_uploader(
             "Upload up to 5 images or videos",
             type=["png", "jpg", "jpeg", "mp4", "mov", "webm"],
             accept_multiple_files=True,
-            key="personality_chat_images",
+            key=images_key,
         )
         chat_media = []
         if uploaded_files:
@@ -1555,19 +1561,21 @@ class LofnApp:
                 st.warning("Only the first 5 files will be used.")
             for file in uploaded_files[:5]:
                 chat_media.append(file)
-        st.session_state['chat_input_images'] = chat_media
+        input_images_key = f"{key_prefix}chat_input_images" if image_mode else "chat_input_images"
+        st.session_state[input_images_key] = chat_media
 
-        if 'chat_history' not in st.session_state:
-            st.session_state['chat_history'] = []
+        history_key = f"{key_prefix}chat_history" if image_mode else "chat_history"
+        if history_key not in st.session_state:
+            st.session_state[history_key] = []
 
-        for msg in st.session_state['chat_history']:
+        for msg in st.session_state[history_key]:
             role = 'user' if isinstance(msg, HumanMessage) else 'assistant'
             with st.chat_message(role):
                 if isinstance(msg.content, list):
                     for part in msg.content:
                         if part.get("type") == "text":
                             st.markdown(part.get("text", ""))
-                        elif part.get("type") in ("image_url", "input_image"):
+                        elif part.get("type") == "image_url":
                             url = part.get("image_url", "")
                             if isinstance(url, dict):
                                 url = url.get("url", "")
@@ -1575,170 +1583,73 @@ class LofnApp:
                                 st.image(base64.b64decode(url.split(",")[1]))
                             else:
                                 st.image(url)
-                        elif part.get("type") in ("video_url", "input_video"):
-                            url = part.get("video_url", "")
-                            if isinstance(url, dict):
-                                url = url.get("url", "")
-                            if url.startswith("data:"):
-                                st.video(base64.b64decode(url.split(",")[1]))
-                            else:
-                                st.video(url)
+                        elif part.get("type") == "file":
+                            file_data = part.get("file", {})
+                            mime = file_data.get("mime_type", "")
+                            b64 = file_data.get("b64_json", "")
+                            if mime.startswith("image/"):
+                                st.image(base64.b64decode(b64))
+                            elif mime.startswith("video/"):
+                                st.video(base64.b64decode(b64))
                 else:
                     st.markdown(msg.content)
 
-        user_input = st.chat_input("Send a message", key="personality_chat_input")
+        input_key = "image2video_chat_input" if image_mode else "personality_chat_input"
+        user_input = st.chat_input("Send a message", key=input_key)
         if user_input:
-            history = st.session_state['chat_history'][:]
-            images = st.session_state.get('chat_input_images', [])
+            history = st.session_state[history_key][:]
+            images = st.session_state.get(input_images_key, [])
             prepared = prepare_image_messages(images)
             user_message = HumanMessage(
                 content=[{"type": "text", "text": user_input}, *[m.content[0] for m in prepared]]
             )
-            st.session_state['chat_history'].append(user_message)
+            st.session_state[history_key].append(user_message)
             with st.chat_message("user"):
                 st.markdown(user_input)
                 for media in prepared:
                     part = media.content[0]
-                    url = part.get("image_url") or part.get("video_url")
-                    if part["type"] in ("image_url", "input_image"):
+                    if part["type"] == "image_url":
+                        url = part["image_url"]
                         if isinstance(url, dict):
                             url = url.get("url", "")
                         st.image(base64.b64decode(url.split(",")[1]))
-                    elif part["type"] in ("video_url", "input_video"):
-                        if isinstance(url, dict):
-                            url = url.get("url", "")
-                        st.video(base64.b64decode(url.split(",")[1]))
-            logger.debug("Personality chat user input: %s", user_input)
-            response_text = run_personality_chat(
-                personality_text,
-                history,
-                user_input,
-                model=self.model,
-                temperature=self.temperature,
-                reasoning_level=st.session_state.get('reasoning_level', 'medium'),
-                debug=self.debug,
-                input_media=[m.content[0] for m in prepared],
-            )
-            logger.debug("Personality chat response: %s", response_text)
+                    elif part["type"] == "file":
+                        file_data = part["file"]
+                        mime = file_data.get("mime_type", "")
+                        b64 = file_data.get("b64_json", "")
+                        if mime.startswith("image/"):
+                            st.image(base64.b64decode(b64))
+                        elif mime.startswith("video/"):
+                            st.video(base64.b64decode(b64))
+            logger.debug(f"{mode} user input: %s", user_input)
+            if mode == "Image to Video Chat":
+                response_text = run_personality_image2video_chat(
+                    personality_text,
+                    history,
+                    user_input,
+                    model=self.model,
+                    temperature=self.temperature,
+                    reasoning_level=st.session_state.get('reasoning_level', 'medium'),
+                    debug=self.debug,
+                    input_media=[m.content[0] for m in prepared],
+                )
+            else:
+                response_text = run_personality_chat(
+                    personality_text,
+                    history,
+                    user_input,
+                    model=self.model,
+                    temperature=self.temperature,
+                    reasoning_level=st.session_state.get('reasoning_level', 'medium'),
+                    debug=self.debug,
+                    input_media=[m.content[0] for m in prepared],
+                )
+            logger.debug(f"{mode} response: %s", response_text)
             with st.chat_message("assistant"):
                 st.markdown(response_text)
-            st.session_state['chat_history'].append(AIMessage(content=response_text))
-        st.session_state['chat_input_images'] = []
-        st.session_state['clear_personality_chat_images'] = True
-
-    def render_image_to_video_chat_section(self):
-        st.subheader("Image to Video Chat")
-        personality_names = [p['name'] for p in PERSONALITY_OPTIONS] + ['Custom']
-        st.session_state['image2video_selected_personality'] = st.selectbox(
-            'Personality',
-            personality_names,
-            index=personality_names.index(
-                st.session_state.get('image2video_selected_personality', personality_names[0])
-            ),
-            key='image2video_personality_select',
-        )
-        if st.session_state['image2video_selected_personality'] == 'Custom':
-            st.session_state['image2video_custom_personality'] = st.text_area(
-                'Custom Personality',
-                value=st.session_state.get('image2video_custom_personality', ''),
-                height=150,
-                key='image2video_custom_personality',
-            )
-        else:
-            st.session_state['image2video_custom_personality'] = next(
-                p['prompt']
-                for p in PERSONALITY_OPTIONS
-                if p['name'] == st.session_state['image2video_selected_personality']
-            )
-        personality_text = st.session_state.get('image2video_custom_personality', '')
-
-        if st.session_state.get('clear_image2video_chat_images'):
-            st.session_state.pop('image2video_chat_images', None)
-            st.session_state['clear_image2video_chat_images'] = False
-
-        st.subheader("Reference Media (Optional)")
-        uploaded_files = st.file_uploader(
-            "Upload up to 5 images or videos",
-            type=["png", "jpg", "jpeg", "mp4", "mov", "webm"],
-            accept_multiple_files=True,
-            key="image2video_chat_images",
-        )
-        chat_media = []
-        if uploaded_files:
-            if len(uploaded_files) > 5:
-                st.warning("Only the first 5 files will be used.")
-            for file in uploaded_files[:5]:
-                chat_media.append(file)
-        st.session_state['image2video_chat_input_images'] = chat_media
-
-        if 'image2video_chat_history' not in st.session_state:
-            st.session_state['image2video_chat_history'] = []
-
-        for msg in st.session_state['image2video_chat_history']:
-            role = 'user' if isinstance(msg, HumanMessage) else 'assistant'
-            with st.chat_message(role):
-                if isinstance(msg.content, list):
-                    for part in msg.content:
-                        if part.get("type") == "text":
-                            st.markdown(part.get("text", ""))
-                        elif part.get("type") in ("image_url", "input_image"):
-                            url = part.get("image_url", "")
-                            if isinstance(url, dict):
-                                url = url.get("url", "")
-                            if url.startswith("data:"):
-                                st.image(base64.b64decode(url.split(",")[1]))
-                            else:
-                                st.image(url)
-                        elif part.get("type") in ("video_url", "input_video"):
-                            url = part.get("video_url", "")
-                            if isinstance(url, dict):
-                                url = url.get("url", "")
-                            if url.startswith("data:"):
-                                st.video(base64.b64decode(url.split(",")[1]))
-                            else:
-                                st.video(url)
-                else:
-                    st.markdown(msg.content)
-
-        user_input = st.chat_input("Send a message", key="image2video_chat_input")
-        if user_input:
-            history = st.session_state['image2video_chat_history'][:]
-            images = st.session_state.get('image2video_chat_input_images', [])
-            prepared = prepare_image_messages(images)
-            user_message = HumanMessage(
-                content=[{"type": "text", "text": user_input}, *[m.content[0] for m in prepared]]
-            )
-            st.session_state['image2video_chat_history'].append(user_message)
-            with st.chat_message("user"):
-                st.markdown(user_input)
-                for media in prepared:
-                    part = media.content[0]
-                    url = part.get("image_url") or part.get("video_url")
-                    if part["type"] in ("image_url", "input_image"):
-                        if isinstance(url, dict):
-                            url = url.get("url", "")
-                        st.image(base64.b64decode(url.split(",")[1]))
-                    elif part["type"] in ("video_url", "input_video"):
-                        if isinstance(url, dict):
-                            url = url.get("url", "")
-                        st.video(base64.b64decode(url.split(",")[1]))
-            logger.debug("Image-to-video chat user input: %s", user_input)
-            response_text = run_personality_image2video_chat(
-                personality_text,
-                history,
-                user_input,
-                model=self.model,
-                temperature=self.temperature,
-                reasoning_level=st.session_state.get('reasoning_level', 'medium'),
-                debug=self.debug,
-                input_media=[m.content[0] for m in prepared],
-            )
-            logger.debug("Image-to-video chat response: %s", response_text)
-            with st.chat_message("assistant"):
-                st.markdown(response_text)
-            st.session_state['image2video_chat_history'].append(AIMessage(content=response_text))
-            st.session_state['image2video_chat_input_images'] = []
-            st.session_state['clear_image2video_chat_images'] = True
+            st.session_state[history_key].append(AIMessage(content=response_text))
+            st.session_state[input_images_key] = []
+            st.session_state[clear_key] = True
 
     def initialize_session_state(self):
         cm_model, prompt_model = self.get_defaults_for_mode('Image Generation')

--- a/tests/test_image_flow.py
+++ b/tests/test_image_flow.py
@@ -16,7 +16,7 @@ def test_openai_accepts_image(monkeypatch):
             assert kwargs["model"].startswith("gpt-5")
             inp = kwargs["input"][-1]["content"]
             assert any(
-                x.get("type") == "input_image" and "file_id" in x.get("image_url", {})
+                x.get("type") == "image_url" and "file_id" in x.get("image_url", {})
                 for x in inp
             )
             return type("R", (), {"output_text": "ok"})

--- a/tests/test_image_inputs.py
+++ b/tests/test_image_inputs.py
@@ -30,6 +30,10 @@ def test_prepare_image_messages_limit():
     msgs = prepare_image_messages(images)
     assert len(msgs) == 5
     for m in msgs:
-        assert m.content[0]["type"] == "input_image"
-        assert m.content[0]["image_url"].startswith("data:image/")
+        part = m.content[0]
+        assert part["type"] == "image_url"
+        url = part["image_url"]
+        if isinstance(url, dict):
+            url = url.get("url", "")
+        assert url.startswith("data:image/")
         assert m.additional_kwargs == {}

--- a/tests/test_prepare_image_messages.py
+++ b/tests/test_prepare_image_messages.py
@@ -51,8 +51,11 @@ def test_prepare_image_messages_inlines_jpeg():
     assert len(msgs) == 1
     msg = msgs[0]
     assert isinstance(msg.content, list)
-    assert msg.content[0]["type"] == "input_image"
-    url = msg.content[0]["image_url"]
+    part = msg.content[0]
+    assert part["type"] == "image_url"
+    url = part["image_url"]
+    if isinstance(url, dict):
+        url = url.get("url", "")
     assert url.startswith("data:image/jpeg;base64")
     assert msg.additional_kwargs == {}
 
@@ -64,5 +67,7 @@ def test_prepare_image_messages_handles_video():
     msgs = prepare_image_messages([data_url])
     assert len(msgs) == 1
     part = msgs[0].content[0]
-    assert part["type"] == "input_video"
-    assert part["video_url"].startswith("data:video/mp4;base64")
+    assert part["type"] == "file"
+    file_data = part.get("file", {})
+    assert file_data.get("mime_type") == "video/mp4"
+    assert file_data.get("b64_json", "").startswith(b64[:10])


### PR DESCRIPTION
## Summary
- replace deprecated `input_image`/`input_video` content with `image_url` and `file`
- unify personality and image-to-video chats into a single mode-selectable chat UI
- adjust OpenAI multimodal helper and tests for new message types

## Testing
- `pytest` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68b5dd4bed2483299a330b2f1dd05388