### PR TITLE
Fix gpt-5 chat message content types

### DIFF
--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -929,13 +929,33 @@ class ChatOpenAIWebSearch(BaseChatModel):
         converted = []
         for m in messages:
             if isinstance(m, SystemMessage):
-                converted.append({"role": "system", "content": m.content})
+                converted.append(
+                    {
+                        "role": "system",
+                        "content": [{"type": "input_text", "text": m.content}],
+                    }
+                )
             elif isinstance(m, HumanMessage):
-                converted.append({"role": "user", "content": m.content})
+                converted.append(
+                    {
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": m.content}],
+                    }
+                )
             elif isinstance(m, AIMessage):
-                converted.append({"role": "assistant", "content": m.content})
+                converted.append(
+                    {
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": m.content}],
+                    }
+                )
             else:
-                converted.append({"role": "user", "content": m.content})
+                converted.append(
+                    {
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": m.content}],
+                    }
+                )
         return converted
 
     def _generate(


### PR DESCRIPTION
## Summary
- ensure gpt-5 web search chat uses new `input_text` and `output_text` message formats for the OpenAI responses API

## Testing
- `PYTHONPATH=$PWD pytest tests/test_prepare_image_messages.py::test_prepare_image_messages_inlines_jpeg -q`

------
https://chatgpt.com/codex/tasks/task_e_68bb85a7949c832988f54ec0a40ff5a8