### PR TITLE
feat: add nano banana image generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@
 | **TikTok Mode** | FLUX Pro v1.1 Ultra 9:16 images rotated for Veo 3 ingestion |
 | **Competition Mode** | Shrinks the prompt to platform limits while preserving nuance; injects Panel + Personality context first |
 | **Model‑Agnostic** | Works with OpenAI, Anthropic, Google Gemini, Meta Llama, and any OpenAI‑compatible local LLM (via Ollama, text‑gen‑webui, etc.) |
+| **Nano Banana** | Gemini 2.5 Flash Image preview for Gemini‑powered image generation |
 | **Phase‑Map Transparency** | A visible flowchart of every stage, emitted with each run |
 | **Ethics & Provenance** | Strong NSFW/harassment filters + anti-copyright infringement checks|
 | **Discord & Webhooks** | Push prompts or rendered assets straight to any channel |

--- a/lofn/image_generation.py
+++ b/lofn/image_generation.py
@@ -32,6 +32,8 @@ import json
 
 import vertexai
 from vertexai.preview.vision_models import ImageGenerationModel
+from google import genai
+from google.genai import types
 
 image_title_schema = {
     "title": str,
@@ -61,6 +63,8 @@ def generate_image(model: str, params: dict, OPENAI_API = Config.OPENAI_API, deb
         return [generate_image_dalle3(params, OPENAI_API, debug = debug)]
     elif model == "Google Imagen 3":
           return generate_google_imagen_image(params, debug=debug)
+    elif model == "Gemini 2.5 Flash Image":
+          return generate_gemini_flash_image(params, debug=debug)
     elif model.startswith("fal-ai/"):
         return generate_fal_image(model, params, debug = debug)
     elif model.startswith("Poe-"):
@@ -148,6 +152,40 @@ def generate_google_imagen_image(params, debug=False):
 
     except Exception as e:
         st.error(f"An error occurred while generating the image with Google Imagen 3: {str(e)}")
+        if debug:
+            st.exception(e)
+        return None
+
+
+def generate_gemini_flash_image(params, debug=False):
+    """Generate images using Gemini 2.5 Flash Image (aka Nano Banana)."""
+    try:
+        client = genai.Client(api_key=Config.GOOGLE_API_KEY)
+        prompt = params.get("prompt", "")
+
+        response = client.models.generate_content(
+            model="gemini-2.5-flash-image-preview",
+            contents=[prompt],
+        )
+
+        image_paths = []
+        idx = 0
+        for candidate in response.candidates:
+            for part in candidate.content.parts:
+                if part.text and debug:
+                    st.write(part.text)
+                elif getattr(part, "inline_data", None):
+                    image = Image.open(BytesIO(part.inline_data.data))
+                    filename = f"gemini_flash_{idx}_{prompt[:40]}.png"
+                    image.save(f"/images/{filename}")
+                    image_paths.append(f"/images/{filename}")
+                    idx += 1
+
+        return image_paths
+    except Exception as e:
+        st.error(
+            f"An error occurred while generating the image with Gemini 2.5 Flash Image: {str(e)}"
+        )
         if debug:
             st.exception(e)
         return None

--- a/lofn/ui.py
+++ b/lofn/ui.py
@@ -236,6 +236,8 @@ class LofnApp:
             ])
         if Config.IDEOGRAM_API_KEY:
             models.append("Ideogram")
+        if Config.GOOGLE_API_KEY:
+            models.append("Gemini 2.5 Flash Image")
         if Config.GCP_PROJECT_ID:
             models.append("Google Imagen 3")
         if Config.OPENAI_API:

--- a/tests/test_gemini_image.py
+++ b/tests/test_gemini_image.py
@@ -1,0 +1,22 @@
+import lofn.image_generation as ig
+from lofn.ui import LofnApp
+import config as root_cfg
+
+
+def test_generate_image_dispatches_to_gemini(monkeypatch):
+    called = {}
+
+    def fake_generate(params, debug=False):
+        called['params'] = params
+        return ['img.png']
+
+    monkeypatch.setattr(ig, 'generate_gemini_flash_image', fake_generate)
+    out = ig.generate_image('Gemini 2.5 Flash Image', {'prompt': 'banana'})
+    assert out == ['img.png']
+    assert called['params']['prompt'] == 'banana'
+
+
+def test_available_image_models_include_gemini(monkeypatch):
+    monkeypatch.setattr(root_cfg.Config, 'GOOGLE_API_KEY', 'key')
+    models = LofnApp.get_available_image_models(object())
+    assert 'Gemini 2.5 Flash Image' in models


### PR DESCRIPTION
## Summary
- support Gemini 2.5 Flash Image (aka Nano Banana) for image generation
- expose the model in the Streamlit UI
- document Nano Banana availability and add regression tests

## Testing
- `PYTHONPATH=.:lofn pytest tests/test_gemini_image.py`
- `PYTHONPATH=.:lofn pytest` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'exceptions')*


------
https://chatgpt.com/codex/tasks/task_e_68bc70f2a46883299596c0a523acfc8f