### PR TITLE
refactor: update pydantic imports

### DIFF
--- a/lofn/image_generation.py
+++ b/lofn/image_generation.py
@@ -10,12 +10,18 @@ import os
 import time
 import asyncio
 from config import Config
-from helpers import *
+try:
+    from helpers import *  # noqa: F403
+except ModuleNotFoundError:  # pragma: no cover - fallback for package import
+    from .helpers import *  # noqa: F403
 import logging
 logger = logging.getLogger(__name__)
 import plotly.graph_objects as go
 import pandas as pd
-from llm_integration import *
+try:
+    from llm_integration import *  # noqa: F403
+except ModuleNotFoundError:  # pragma: no cover - fallback for package import
+    from .llm_integration import *  # noqa: F403
 from langchain.chains.structured_output.base import create_structured_output_runnable
 from langchain_anthropic import ChatAnthropic
 from langchain_openai import ChatOpenAI

--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -24,7 +24,7 @@ from langchain.schema import OutputParserException
 from langchain.callbacks import AsyncIteratorCallbackHandler
 from langchain.schema import BaseMessage, AIMessage, HumanMessage, SystemMessage, ChatGeneration, ChatResult
 from langchain_core.callbacks.manager import CallbackManagerForLLMRun
-from langchain_core.pydantic_v1 import PrivateAttr
+from pydantic import PrivateAttr
 from langchain_core.language_models.llms import LLM
 from typing import Any, Dict, List, Optional, Tuple
 from dataclasses import dataclass
@@ -90,8 +90,6 @@ except ModuleNotFoundError:  # pragma: no cover - fallback for package import
         display_temporary_results,
         display_temporary_results_no_expander,
     )
-from langchain_core.callbacks.manager import CallbackManagerForLLMRun
-from langchain_core.pydantic_v1 import PrivateAttr
 import openai  # For the advanced "o1" usage if needed
 from openai import OpenAI
 try:

--- a/lofn/o1_integration.py
+++ b/lofn/o1_integration.py
@@ -9,8 +9,7 @@ from langchain.schema import (
 )
 from langchain.chat_models.base import BaseChatModel
 from langchain_core.callbacks.manager import CallbackManagerForLLMRun
-# This PrivateAttr is from pydantic < 2, often used with langchain's pydantic_v1
-from langchain_core.pydantic_v1 import Field, PrivateAttr, root_validator
+from pydantic import Field, PrivateAttr
 from openai import OpenAI  # openai>=1.0.0 style usage
 
 


### PR DESCRIPTION
## Summary
- replace deprecated `langchain_core.pydantic_v1` imports with direct `pydantic` equivalents
- add package-relative fallbacks for helper and LLM modules

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'vertexai')*

------
https://chatgpt.com/codex/tasks/task_e_68bc9ffba7c48329a1aed052d1e7c703