### PR TITLE
fix: repair unescaped quotes in JSON parsing

### DIFF
--- a/lofn/parsing.py
+++ b/lofn/parsing.py
@@ -99,8 +99,18 @@ def _escape_control_chars_in_strings(s: str) -> str:
                     out.append(ch)
                     esc = True
                 elif ch == '"':
-                    out.append(ch)
-                    in_str = False
+                    # If the quote isn't followed by a typical string terminator
+                    # (comma, colon, closing brace/bracket), treat it as a
+                    # literal quote and escape it. GPT-5 occasionally emits
+                    # unescaped quotes inside strings like: "Hello "World"".
+                    j = i + 1
+                    while j < n and s[j].isspace():
+                        j += 1
+                    if j < n and s[j] not in ',:}]':
+                        out.append('\\"')
+                    else:
+                        out.append(ch)
+                        in_str = False
                 elif ch == '\n':
                     out.append('\\n')
                 elif ch == '\r':

--- a/tests/test_parsing_gpt5_noise.py
+++ b/tests/test_parsing_gpt5_noise.py
@@ -53,6 +53,12 @@ def test_multiline_string_in_json_value():
     assert "H.A.T.C.H" in out["personality_prompt"] or "HB Ghost" in out["personality_prompt"]
 
 
+def test_unescaped_quotes_in_json_value():
+    raw = """content='{"personality_prompt": "Hello "World""}'"""
+    out = select_best_json_candidate(raw, {"personality_prompt": str})
+    assert out["personality_prompt"] == 'Hello "World"'
+
+
 def test_claude_panel_transcript():
     raw = (
         "content=[{'signature': 'abc', 'thinking': 'x'},"


### PR DESCRIPTION
## Summary
- handle stray double quotes in GPT-5 JSON strings
- test parser against unescaped quote noise

## Testing
- `PYTHONPATH=.:lofn pytest tests/test_parsing_gpt5_noise.py`
- `pytest` *(fails: No module named 'PIL')*


------
https://chatgpt.com/codex/tasks/task_e_68bd272b2ee48329b164d9d41fba56d3