### PR TITLE
Validate schema when parsing video and music responses

### DIFF
--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -1479,7 +1479,9 @@ def run_chain_with_retries(
                             simple_schema[key] = dict
                         else:
                             simple_schema[key] = val
-                parsed_output = select_best_json_candidate(str(output), simple_schema, debug)
+                parsed_output = select_best_json_candidate(
+                    str(output), simple_schema, expected_schema, debug
+                )
                 if expected_schema and not validate_schema(parsed_output, expected_schema):
                     raise ValueError("Parsed JSON does not match the expected schema. Parsed Output {parsed_output}")
                 if debug:
@@ -1529,7 +1531,9 @@ def run_chain_with_retries_raw(
                             simple_schema[key] = dict
                         else:
                             simple_schema[key] = val
-                parsed_output = select_best_json_candidate(str(output), simple_schema)
+                parsed_output = select_best_json_candidate(
+                    str(output), simple_schema, expected_schema
+                )
                 schema_validator(parsed_output)
                 if debug:
                     st.write("Successfully parsed JSON output")

--- a/lofn/parsing.py
+++ b/lofn/parsing.py
@@ -357,17 +357,36 @@ def _normalize_to_schema(obj: JSON, schema: Dict[str, Union[type, str]]) -> Opti
                 return None
     return out
 
-def select_best_json_candidate(raw_text: str, schema: Dict[str, Union[type, str]], debug : bool = False) -> dict:
+def select_best_json_candidate(
+    raw_text: str,
+    schema: Dict[str, Union[type, str]],
+    expected_schema: Dict | None = None,
+    debug: bool = False,
+) -> dict:
+    """Find and return the best JSON object matching ``schema``.
+
+    If ``expected_schema`` is provided, each parsed candidate is also validated
+    against it before being returned. This allows us to try additional
+    candidates when the first parse yields JSON that doesn't actually conform
+    to the desired structure.
     """
-    Finds and returns the best JSON object matching 'schema'.
-    Raises ValueError with a useful message if nothing matches.
-    """
-    text = _minimal_cleanup(_strip_code_fences(raw_text.replace("""\'""","\u0027").replace("""\\'""","\u0027")))
+    text = _minimal_cleanup(
+        _strip_code_fences(
+            raw_text.replace("""\'""", "\u0027").replace("""\\'""", "\u0027")
+        )
+    )
+
+    def _maybe_return(norm: Optional[dict]) -> Optional[dict]:
+        if norm is None:
+            return None
+        if expected_schema and not validate_schema(norm, expected_schema):
+            return None
+        return norm
 
     # 0) Direct parse: if whole message IS the JSON
     try:
         obj = _loads_tolerant(text, debug)
-        norm = _normalize_to_schema(obj, schema)
+        norm = _maybe_return(_normalize_to_schema(obj, schema))
         if norm is not None:
             return norm
     except Exception:
@@ -375,8 +394,11 @@ def select_best_json_candidate(raw_text: str, schema: Dict[str, Union[type, str]
 
     # 0b) Try robust repair-based parser
     try:
-        repaired_obj, _, _ = parse_with_repairs(text.replace('''\n''','').replace('''\\n''',''), required_keys=list(schema.keys()))
-        norm = _normalize_to_schema(repaired_obj, schema)
+        repaired_obj, _, _ = parse_with_repairs(
+            text.replace("""\n""", "").replace("""\\n""", ""),
+            required_keys=list(schema.keys()),
+        )
+        norm = _maybe_return(_normalize_to_schema(repaired_obj, schema))
         if norm is not None:
             return norm
     except Exception:
@@ -405,7 +427,7 @@ def select_best_json_candidate(raw_text: str, schema: Dict[str, Union[type, str]
             continue
             if debug:
                 raise ValueError('Failed to parse {cleaned_cand} with _loads_tolerant')
-        norm = _normalize_to_schema(value, schema)
+        norm = _maybe_return(_normalize_to_schema(value, schema))
         if norm is not None:
             parsed.append((norm, len(cand)))
 


### PR DESCRIPTION
## Summary
- extend `select_best_json_candidate` to validate each candidate against an expected schema
- pass schemas through when parsing video and music outputs

## Testing
- `PYTHONPATH=$PYTHONPATH:/workspace/lofn/lofn pytest` *(fails: ModuleNotFoundError: No module named 'fal_client', No module named 'langchain')*

------
https://chatgpt.com/codex/tasks/task_e_68c078712aa0832984824bd8de5efd4f