### PR TITLE
Fix image input handling and Gemini import fallback

### DIFF
--- a/lofn/image_generation.py
+++ b/lofn/image_generation.py
@@ -10,12 +10,18 @@ import os
 import time
 import asyncio
 from config import Config
-from helpers import *  # noqa: F403
+try:
+    from .helpers import *  # type: ignore # noqa: F401,F403
+except ModuleNotFoundError:  # pragma: no cover - fallback when run as script
+    from helpers import *  # type: ignore # noqa: F401,F403
 import logging
 logger = logging.getLogger(__name__)
 import plotly.graph_objects as go
 import pandas as pd
-from llm_integration import *  
+try:
+    from .llm_integration import *  # type: ignore # noqa: F401,F403
+except ModuleNotFoundError:  # pragma: no cover - fallback when run as script
+    from llm_integration import *  # type: ignore # noqa: F401,F403
 from langchain.chains.structured_output.base import create_structured_output_runnable
 from langchain_anthropic import ChatAnthropic
 from langchain_openai import ChatOpenAI

--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -59,10 +59,16 @@ except ModuleNotFoundError:  # pragma: no cover - fallback for package import
         compress_image_bytes,
     )
 
-from parsing import (
+try:
+    from .parsing import (
         select_best_json_candidate,
         validate_schema,
-)
+    )
+except ModuleNotFoundError:  # pragma: no cover - fallback for script usage
+    from parsing import (
+        select_best_json_candidate,
+        validate_schema,
+    )
 import plotly.graph_objects as go
 import random
 import numpy as np
@@ -447,8 +453,18 @@ def call_anthropic_with_images(user_text: str, images: List[ImageAsset], model: 
     return out, usage_dict
 
 
-def call_gemini_with_images(user_text: str, images: List[ImageAsset], model: str = "gemini-1.5-pro") -> Tuple[str, Optional[dict]]:
-    import google.generativeai as genai
+def call_gemini_with_images(
+    user_text: str, images: List[ImageAsset], model: str = "gemini-1.5-pro"
+) -> Tuple[str, Optional[dict]]:
+    try:  # Prefer new package name but support legacy import
+        import google.generativeai as genai  # type: ignore
+    except ModuleNotFoundError:  # pragma: no cover - import fallback
+        try:
+            import google.genai as genai  # type: ignore
+        except ModuleNotFoundError as exc:
+            raise ModuleNotFoundError(
+                "google.generativeai or google.genai is required"
+            ) from exc
 
     genai.configure()
     ensure_vision_capable("google", model, bool(images))
@@ -598,7 +614,7 @@ def prepare_image_messages(images: List) -> List[HumanMessage]:
         if mime and mime.startswith("image/"):
             messages.append(
                 HumanMessage(
-                    content=[{"type": "image_url", "image_url": {"url": url}}]
+                    content=[{"type": "image_url", "image_url": url}]
                 )
             )
         elif mime and mime.startswith("video/"):

--- a/lofn/parsing.py
+++ b/lofn/parsing.py
@@ -4,7 +4,7 @@ import re
 import streamlit as st
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
-from lofjson import parse_with_repairs
+from .lofjson import parse_with_repairs
 from json_repair import repair_json
 
 JSON = Union[dict, list, str, int, float, bool, None]

--- a/tests/test_image_inputs.py
+++ b/tests/test_image_inputs.py
@@ -33,7 +33,6 @@ def test_prepare_image_messages_limit():
         part = m.content[0]
         assert part["type"] == "image_url"
         url = part["image_url"]
-        if isinstance(url, dict):
-            url = url.get("url", "")
+        assert isinstance(url, str)
         assert url.startswith("data:image/")
         assert m.additional_kwargs == {}

--- a/tests/test_parsing_gpt5_noise.py
+++ b/tests/test_parsing_gpt5_noise.py
@@ -8,7 +8,7 @@ REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 sys.path.insert(0, REPO_ROOT)
 
 from lofn.parsing import select_best_json_candidate
-from lofjson import parse_with_repairs
+from lofn.lofjson import parse_with_repairs
 
 
 def test_personality_from_logged_content():

--- a/tests/test_prepare_image_messages.py
+++ b/tests/test_prepare_image_messages.py
@@ -54,8 +54,7 @@ def test_prepare_image_messages_inlines_jpeg():
     part = msg.content[0]
     assert part["type"] == "image_url"
     url = part["image_url"]
-    if isinstance(url, dict):
-        url = url.get("url", "")
+    assert isinstance(url, str)
     assert url.startswith("data:image/jpeg;base64")
     assert msg.additional_kwargs == {}
 


### PR DESCRIPTION
## Summary
- send image URLs as strings for OpenAI image prompts
- add google.genai fallback when google.generativeai is missing
- normalize internal imports to use package-relative paths
- tighten image input tests to require string URLs

## Testing
- `pytest tests/test_prepare_image_messages.py tests/test_image_inputs.py tests/test_parsing_gpt5_noise.py`
- `pytest` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'exceptions')*

------
https://chatgpt.com/codex/tasks/task_e_68c23d4730e08329916c4d83be9ef1fd