### PR TITLE
Fix GPT-5 image payloads for OpenAI Responses API

### DIFF
--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -314,10 +314,14 @@ def _normalize_responses_messages(
                         img = p.get("image_url")
                         detail = p.get("detail", "auto")
                         if isinstance(img, dict):
-                            image_url = img
-                        else:
-                            image_url = {"url": img}
-                        parts.append({"type": "input_image", "image_url": image_url, "detail": detail})
+                            file_id = img.get("file_id")
+                            url = img.get("url")
+                            if file_id:
+                                parts.append({"type": "input_image", "file_id": file_id, "detail": detail})
+                            elif url:
+                                parts.append({"type": "input_image", "image_url": url, "detail": detail})
+                        elif isinstance(img, str):
+                            parts.append({"type": "input_image", "image_url": img, "detail": detail})
                     elif ptype in ("input_file", "file"):
                         fid = p.get("file_id") or p.get("id")
                         if fid:
@@ -350,32 +354,29 @@ def call_openai_gpt5_multimodal(
 ):
     """Send text plus optional images to OpenAI GPT-5 via the Responses API."""
     client = OpenAI()
-    user_content = []
+    user_parts: List[Dict[str, Any]] = []
 
     if image_blobs:
         for blob in image_blobs:
-            img_bytes, _ = normalize_image_bytes(blob)
-            uploaded = client.files.create(
-                file=io.BytesIO(img_bytes), purpose="vision"
-            )
-            user_content.append(
+            img_bytes, mime = normalize_image_bytes(blob)
+            b64 = base64.b64encode(img_bytes).decode()
+            data_url = f"data:{mime};base64,{b64}"
+            user_parts.append(
                 {
-                    "type": "image_url",
-                    "image_url": {"file_id": uploaded.id},
+                    "type": "input_image",
+                    "image_url": data_url,
                     "detail": "high",
                 }
             )
 
-    user_content.append({"type": "text", "text": user_text})
+    user_parts.append({"type": "input_text", "text": user_text})
 
-    messages = []
+    messages: List[Dict[str, Any]] = []
     if system_text:
         messages.append(
-            {"role": "system", "content": [{"type": "text", "text": system_text}]}
+            {"role": "system", "content": [{"type": "input_text", "text": system_text}]}
         )
-    messages.append({"role": "user", "content": user_content})
-
-    messages = _normalize_responses_messages(messages)
+    messages.append({"role": "user", "content": user_parts})
 
     resp = client.responses.create(
         model=model, input=messages, temperature=temperature
@@ -1076,15 +1077,15 @@ class ChatOpenAIWebSearch(BaseChatModel):
                         parts.append({"type": "input_text" if role != "assistant" else "output_text", "text": txt})
                     elif ptype in {"image_url", "input_image"}:
                         image = p.get("image_url")
-                        image = {"url": image} if isinstance(image, str) else (image or {})
-                        url = image.get("url", "")
                         detail = p.get("detail", "auto")
-                        if isinstance(url, str) and url.startswith("data:"):
-                            header, b64 = url.split(",", 1)
-                            blob = base64.b64decode(b64)
-                            uploaded = self._client.files.create(file=io.BytesIO(blob), purpose="vision")
-                            parts.append({"type": "input_image", "image_url": {"file_id": uploaded.id}, "detail": detail})
-                        else:
+                        if isinstance(image, dict):
+                            file_id = image.get("file_id")
+                            url = image.get("url")
+                            if file_id:
+                                parts.append({"type": "input_image", "file_id": file_id, "detail": detail})
+                            elif url:
+                                parts.append({"type": "input_image", "image_url": url, "detail": detail})
+                        elif isinstance(image, str):
                             parts.append({"type": "input_image", "image_url": image, "detail": detail})
                     elif ptype == "file":
                         f = p.get("file", {})

--- a/tests/test_image_flow.py
+++ b/tests/test_image_flow.py
@@ -16,19 +16,12 @@ def test_openai_accepts_image(monkeypatch):
             assert kwargs["model"].startswith("gpt-5")
             inp = kwargs["input"][-1]["content"]
             assert any(
-                x.get("type") in ("image_url", "input_image")
-                and "file_id" in (x.get("image_url") or {})
+                x.get("type") == "input_image" and isinstance(x.get("image_url"), str)
                 for x in inp
             )
             return type("R", (), {"output_text": "ok"})
 
-    class FakeFiles:
-        @staticmethod
-        def create(**kwargs):
-            return type("F", (), {"id": "file-123"})
-
     class FakeClient:
-        files = FakeFiles()
         responses = FakeResponses()
 
     monkeypatch.setattr(li, "OpenAI", lambda: FakeClient())


### PR DESCRIPTION
## Summary
- Correct GPT-5 multimodal message normalization to send `input_image` parts with direct `image_url` strings or `file_id`
- Send base64 data URLs instead of file objects in `call_openai_gpt5_multimodal`
- Update GPT-5 chat test to check for string `image_url`

## Testing
- `PYTHONPATH=. pytest tests/test_image_flow.py tests/test_image_inputs.py tests/test_prepare_image_messages.py -q` *(fails: No module named 'fastapi_poe', 'plotly')*

------
https://chatgpt.com/codex/tasks/task_e_68c2497d5dc883298f3e663e06dd6928