### PR TITLE
Fix image chat for Gemini and Claude

### DIFF
--- a/lofn/llm_integration.py
+++ b/lofn/llm_integration.py
@@ -476,7 +476,7 @@ def call_gemini_with_images(
     client = genai.Client(api_key=os.environ.get("GOOGLE_API_KEY"))
     parts: List[Any] = [user_text]
     for img in images:
-        parts.append(types.Part.from_bytes(img.data, mime_type=img.mime))
+        parts.append(types.Part.from_bytes(data=img.data, mime_type=img.mime))
 
     usage_dict = None
     try:
@@ -620,7 +620,7 @@ def prepare_image_messages(images: List) -> List[HumanMessage]:
         if mime and mime.startswith("image/"):
             messages.append(
                 HumanMessage(
-                    content=[{"type": "image_url", "image_url": url}]
+                    content=[{"type": "image_url", "image_url": {"url": url}}]
                 )
             )
         elif mime and mime.startswith("video/"):

--- a/tests/test_image_inputs.py
+++ b/tests/test_image_inputs.py
@@ -33,6 +33,6 @@ def test_prepare_image_messages_limit():
         part = m.content[0]
         assert part["type"] == "image_url"
         url = part["image_url"]
-        assert isinstance(url, str)
-        assert url.startswith("data:image/")
+        assert isinstance(url, dict)
+        assert url.get("url", "").startswith("data:image/")
         assert m.additional_kwargs == {}

--- a/tests/test_prepare_image_messages.py
+++ b/tests/test_prepare_image_messages.py
@@ -54,8 +54,8 @@ def test_prepare_image_messages_inlines_jpeg():
     part = msg.content[0]
     assert part["type"] == "image_url"
     url = part["image_url"]
-    assert isinstance(url, str)
-    assert url.startswith("data:image/jpeg;base64")
+    assert isinstance(url, dict)
+    assert url.get("url", "").startswith("data:image/jpeg;base64")
     assert msg.additional_kwargs == {}
 
 


### PR DESCRIPTION
## Summary
- fix Gemini image uploads by passing data as named argument
- send image URLs as objects so Claude can parse them
- update tests for new image message format

## Testing
- `PYTHONPATH=. pytest tests/test_prepare_image_messages.py tests/test_image_inputs.py -q`
- `PYTHONPATH=.:./lofn pytest -q` *(fails: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68c24be01e048329bef38352c7571e0c